### PR TITLE
ML1 patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+﻿evidence/
+security/evidence/
+scan_report*.csv
+__pycache__/
+.venv/

--- a/security/strategies/patch_applications.py
+++ b/security/strategies/patch_applications.py
@@ -1,7 +1,357 @@
+# security/strategies/patch_applications.py
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Dict, Any, Iterable, Optional
 from .overview import Strategy
+import io, os, re
 
-class PatchApplications(Strategy):
-    id = "PA"
-    name = "Patch Applications"
+# -------------------- Optional deps (no hard-crash) --------------------
+try:
+    import fitz  # PyMuPDF (PDF)
+except Exception:
+    fitz = None
+
+try:
+    from docx import Document as DocxDocument  # python-docx
+except Exception:
+    DocxDocument = None
+
+try:
+    import pytesseract
+    from PIL import Image, ImageOps, ImageFilter, ImageStat, UnidentifiedImageError
+    _TESS_PATH = os.environ.get("TESSERACT_CMD") or r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+    if Path(_TESS_PATH).exists():
+        pytesseract.pytesseract.tesseract_cmd = _TESS_PATH
+except Exception:
+    pytesseract = None
+    Image = None
+    ImageOps = None
+    ImageFilter = None
+    ImageStat = None
+    class UnidentifiedImageError(Exception): ...
+# ----------------------------------------------------------------------
+
+# Evidence we consider
+EXTS = {".txt", ".log", ".pdf", ".docx", ".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".webp"}
+
+# Filename hints
+FILENAME_HINTS = ("winget_upgrade", "winget-upgrade", "winget upgrades", "winget upg", "winget upgrade")
+
+# Apps to prioritise if pending (raise priority text, but Level stays ML1)
+CRITICAL_PATTERNS = [
+    r"\b(Microsoft\s*Edge|Google\s*Chrome|Mozilla\s*Firefox)\b",
+    r"\b(Teams|Zoom|Slack)\b",
+    r"\b(7-?Zip|WinRAR)\b",
+    r"\b(Java|JRE|JDK|Temurin|OpenJDK)\b",
+    r"\b(Node\.js|Python\s*3)\b",
+    r"\b(Adobe\s+Acrobat|Adobe\s+Reader|VLC)\b",
+    r"\b(Wireshark|PuTTY)\b",
+]
+
+# ------------------------------------ helpers ------------------------------------
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+def _resolve_evidence_dir() -> Path:
+    env = os.environ.get("PATCH_APPLICATIONS_DIR")
+    if env:
+        p = Path(env)
+        if p.exists():
+            return p
+    root = _project_root()
+    for c in [root / "evidence" / "patch_applications",
+              root / "security" / "evidence" / "patch_applications"]:
+        if c.exists():
+            return c
+    return root / "evidence" / "patch_applications"
+
+def _iter_evidence_files(root: Path) -> Iterable[Path]:
+    if not root.exists():
+        return []
+    for p in sorted(root.iterdir()):
+        if p.is_file() and p.suffix.lower() in EXTS:
+            yield p
+
+# ---------- OCR tuned for dark console screenshots ----------
+def _ocr_image_bytes(data: bytes) -> str:
+    if not pytesseract or not Image:
+        return ""
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            img = img.convert("L")
+            if ImageStat:
+                mean_luma = ImageStat.Stat(img).mean[0]
+                if mean_luma < 80:  # dark theme → invert
+                    img = ImageOps.invert(img)
+            img = ImageOps.autocontrast(img)
+            w, h = img.size
+            img = img.resize((int(w * 1.5), int(h * 1.5)))
+            if ImageFilter:
+                img = img.filter(ImageFilter.SHARPEN)
+            return pytesseract.image_to_string(img, config="--psm 6 --oem 3")
+    except UnidentifiedImageError:
+        return ""
+    except Exception:
+        return ""
+# -----------------------------------------------------------
+
+def _extract_text(path: Optional[Path]) -> str:
+    if not path:
+        return ""
+    s = path.suffix.lower()
+    try:
+        if s in {".txt", ".log"}:
+            return path.read_text(errors="ignore")
+        if s == ".pdf" and fitz:
+            out = []
+            with fitz.open(path) as doc:
+                for page in doc:
+                    out.append(page.get_text() or "")
+            return "\n".join(out)
+        if s == ".docx" and DocxDocument:
+            d = DocxDocument(str(path))
+            return "\n".join(p.text for p in d.paragraphs)
+        if s in {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".webp"}:
+            return _ocr_image_bytes(path.read_bytes())
+        return path.read_text(errors="ignore")
+    except Exception:
+        return ""
+
+def _looks_like_winget(text: str, fname: str) -> bool:
+    low = fname.lower()
+    if any(h in low for h in FILENAME_HINTS):
+        return True
+    return bool(
+        re.search(r"\bwinget\b", text, re.I)
+        and re.search(r"\b(Name|Package)\b", text)
+        and re.search(r"\bVersion\b", text)
+        and re.search(r"\bAvailable\b", text)
+    )
+
+# “No updates” vs “X upgrades available”
+NO_UPDATES_RE = re.compile(r"\bNo (applicable )?updates? (found|available)\b", re.I)
+FOOTER_COUNT_RE = re.compile(r"\b(\d+)\s+upgrades?\s+available\b", re.I)
+
+def _clean_ocr(text: str) -> str:
+    return (
+        text.replace("—", "-").replace("–", "-")
+            .replace("I", "|")  # common OCR confusion for pipes
+    )
+
+def _parse_winget_upgrade(text: str) -> List[Dict[str, str]]:
+    """
+    Parse `winget upgrade` table into rows: {name, id, version, available, source}
+    Works with TXT and OCR'ed screenshots; tolerant to wrapping.
+    """
+    rows: List[Dict[str, str]] = []
+    txt = _clean_ocr(text)
+    lines = [ln.rstrip() for ln in txt.splitlines() if ln.strip()]
+
+    # Find header (order may vary)
+    header_idx = -1
+    for i, ln in enumerate(lines):
+        if re.search(r"\b(Name|Package)\b", ln) and re.search(r"\bVersion\b", ln) and re.search(r"\bAvailable\b", ln):
+            header_idx = i
+            break
+    if header_idx == -1:
+        return rows
+
+    # Parse body until footer
+    for ln in lines[header_idx + 1:]:
+        if re.match(r"^[\-\=_]{5,}$", ln):
+            continue
+        if FOOTER_COUNT_RE.search(ln):
+            break
+        parts = re.split(r"\s{2,}", ln.strip())
+        if len(parts) < 3:
+            continue
+        name = parts[0]
+        version = parts[1] if len(parts) >= 2 else ""
+        available = parts[2] if len(parts) >= 3 else ""
+        pkg_id = parts[3] if len(parts) >= 4 else ""
+        source = parts[4] if len(parts) >= 5 else ""
+        if not name or not (version or available):
+            continue
+        rows.append({
+            "name": name,
+            "id": pkg_id,
+            "version": version,
+            "available": available,
+            "source": source,
+        })
+
+    # Deduplicate by (name, available)
+    dedup: Dict[tuple, Dict[str, str]] = {}
+    for r in rows:
+        key = (r["name"], r["available"])
+        dedup[key] = r
+    return list(dedup.values())
+
+def _fallback_names(text: str) -> List[str]:
+    """
+    If row parsing fails but it clearly looks like a winget table,
+    try to pull left-column names as a fallback sample.
+    """
+    names = []
+    for ln in text.splitlines():
+        ln = ln.strip()
+        # Heuristic: names tend not to contain "->", and have spaces; skip headers
+        if not ln or "Version" in ln or "Available" in ln or ln.startswith("-"):
+            continue
+        if re.search(r"\b(Name|Package)\b", ln):
+            continue
+        # Take everything before 2+ spaces as the "name"
+        m = re.split(r"\s{2,}", ln)
+        if m and len(m[0]) >= 3:
+            names.append(m[0][:80])
+    return names[:12]
+
+def _find_critical(rows: List[Dict[str, str]], text: str) -> List[str]:
+    crit = []
+    # from parsed rows
+    for r in rows:
+        nm = f"{r.get('name','')} {r.get('id','')}"
+        for pat in CRITICAL_PATTERNS:
+            if re.search(pat, nm, re.I):
+                crit.append(r.get("name") or r.get("id") or nm)
+                break
+    # if no rows, try the raw text
+    if not crit:
+        for pat in CRITICAL_PATTERNS:
+            m = re.search(pat, text, re.I)
+            if m:
+                crit.append(m.group(0))
+    # dedup
+    seen = set()
+    out = []
+    for c in crit:
+        k = c.lower()
+        if k not in seen:
+            seen.add(k)
+            out.append(c)
+    return out
+
+# ---------------------------------- core builder ----------------------------------
+def _build_hit(ev_text: str, ev_name: str, ev_path: Optional[Path]) -> Dict[str, Any] | None:
+    if not _looks_like_winget(ev_text, ev_name):
+        return None
+
+    # Default: assume FAIL unless we positively see "No updates..."
+    none_found = bool(NO_UPDATES_RE.search(ev_text))
+    footer_m = FOOTER_COUNT_RE.search(ev_text)
+    footer_count = int(footer_m.group(1)) if footer_m else None
+
+    if none_found:
+        rows: List[Dict[str, str]] = []
+        pending_count = 0
+        parsed_row_count = 0
+        detection_notes = "Explicit 'No updates found/available' detected."
+    else:
+        rows = _parse_winget_upgrade(ev_text)
+        parsed_row_count = len(rows)
+        pending_count = parsed_row_count
+
+        # Footer fail-safe: if the screenshot says "X upgrades available" but rows == 0, still FAIL
+        if (pending_count == 0) and (footer_count is not None) and (footer_count > 0):
+            pending_count = footer_count
+            # Try to salvage sample names
+            sample_names = _fallback_names(ev_text)
+            rows = [{"name": n, "id": "", "version": "", "available": "", "source": ""} for n in sample_names]
+            detection_notes = f"Footer fail-safe used (saw '{footer_count} upgrades available')."
+        else:
+            detection_notes = "Parsed rows from table." if pending_count > 0 else "Parsed table with zero rows."
+
+    critical = _find_critical(rows, ev_text) if pending_count > 0 else []
+
+    # ---- Output fields ----
+    passed = (pending_count == 0)  # PASS only when zero updates
+    # Level column should show ML1 as requested
+    level = "ML1"
+    # Keep priority higher if critical apps pending
+    priority = "P2" if critical else ("P4" if passed else "P4")
+
+    # Build sample list for the PDF
+    sample = []
+    for r in rows[:12]:
+        n = r.get("name") or r.get("id") or "package"
+        v = r.get("version") or "?"
+        a = r.get("available") or "?"
+        if v == "?" and a == "?":
+            sample.append(n)
+        else:
+            sample.append(f"{n} ({v} → {a})")
+
+    recommendation = (
+        "Run 'winget upgrade --all --silent --accept-source-agreements --accept-package-agreements' "
+        "or deploy via Intune/SCCM to all devices. Enforce auto-update policies for browsers and "
+        "high-risk apps. Prefer stable/LTS channels where applicable. For ML1 timelines: remediate "
+        "critical/weaponised within 48h; other non-critical within 2 weeks."
+    )
+    if critical:
+        recommendation = (
+            "Prioritise updating critical apps immediately (browsers, collaboration tools, runtimes). "
+        ) + recommendation
+
+    return {
+        "test_id": "E8-PA-ML1-001",
+        "sub_strategy": "Patch Applications — Winget Pending Updates",
+        "detected_level": level,                 # ← ML1 as requested
+        "pass_fail": "pass" if passed else "fail",
+        "priority": priority,
+        "recommendation": recommendation,
+        "evidence": {
+            "source_file": ev_name,
+            "absolute_path": str(ev_path) if ev_path else "",
+            "pending_count": pending_count,
+            "parsed_row_count": parsed_row_count,
+            "critical_matches": critical,
+            "sample_pending": sample,
+            "footer_fail_safe_used": bool(footer_count and parsed_row_count == 0),
+            "winget_footer_count": footer_count,
+            "none_updates_phrase_detected": none_found,
+        },
+    }
+
+# ---------------------------------- Strategy ----------------------------------
+class PatchApplicationsML1(Strategy):
+    """
+    ML1 detector for pending application updates based on 'winget upgrade' output.
+    PASS only when no updates remain. Level column is set to 'ML1'.
+    """
+    name = "Patch Applications (ML1)"
+    key  = "patch_applications_ml1"
+    EVIDENCE_DIR = _resolve_evidence_dir()
+
     def description(self) -> str:
-        return "To be described"
+        return (
+            "Parses 'winget upgrade' output (TXT/LOG, PDF/DOCX, or dark-theme screenshots) to detect "
+            "pending application updates. PASS only when zero updates remain. Level = ML1. "
+            "Includes a footer fail-safe so 'X upgrades available' can never pass."
+        )
+
+    def emit_hits(self, text: str = "", source_file: str = "", **kwargs) -> List[Dict[str, Any]]:
+        hits: List[Dict[str, Any]] = []
+
+        # ---- SINGLE-FILE MODE (UI uploads) ----
+        if source_file:
+            ev_path: Optional[Path] = None
+            fp = kwargs.get("full_path")
+            if fp:
+                try:
+                    ev_path = Path(fp)
+                except Exception:
+                    ev_path = None
+            ev_text = text or (_extract_text(ev_path) if ev_path and ev_path.exists() else "")
+            h = _build_hit(ev_text, source_file, ev_path)
+            return [h] if h else []
+
+        # ---- FOLDER MODE (repo evidence) ----
+        for ev_path in _iter_evidence_files(self.EVIDENCE_DIR):
+            ev_text = _extract_text(ev_path)
+            if not _looks_like_winget(ev_text, ev_path.name):
+                continue
+            h = _build_hit(ev_text, ev_path.name, ev_path)
+            if h:
+                hits.append(h)
+
+        return hits

--- a/security/strategies/patch_operating_systems.py
+++ b/security/strategies/patch_operating_systems.py
@@ -1,7 +1,299 @@
+# security/strategies/patch_operating_systems.py
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Dict, Any, Iterable, Optional, Tuple
 from .overview import Strategy
+from datetime import datetime, timedelta
+import io, os, re
 
-class PatchOperatingSystems(Strategy):
-    id = "POS"
-    name = "Patch Operating Systems"
+# -------------------- Optional deps (no hard-crash) --------------------
+try:
+    import fitz  # PyMuPDF for PDF text extraction
+except Exception:
+    fitz = None
+
+try:
+    from docx import Document as DocxDocument  # python-docx
+except Exception:
+    DocxDocument = None
+
+try:
+    import pytesseract
+    from PIL import Image, ImageOps, ImageFilter, ImageStat, UnidentifiedImageError
+    _TESS = os.environ.get("TESSERACT_CMD") or r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+    if Path(_TESS).exists():
+        pytesseract.pytesseract.tesseract_cmd = _TESS
+except Exception:
+    pytesseract = None
+    Image = None
+    ImageOps = None
+    ImageFilter = None
+    ImageStat = None
+    class UnidentifiedImageError(Exception): ...
+# -------------------------------------------------------------------------
+
+# Evidence we consider
+EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".webp", ".pdf", ".docx", ".txt", ".log"}
+
+# Filename hints typical for OS patch/build evidence
+FILENAME_HINTS = (
+    "winupdate_home", "winupdate_history",
+    "system_about", "settings_about",
+    "os_build", "winver",
+    "update_status", "update_settings",
+)
+
+# OS patching/build signals
+KEYWORDS = [
+    r"\bWindows Update\b",
+    r"\b(Cumulative|Feature)\s+update\b",
+    r"\bKB\d{6,}\b",
+    r"\bInstalled on\b|\bLast checked\b|\bCheck for updates\b|\bYou'?re up to date\b",
+    r"\bWindows (10|11)\b",
+    r"\bVersion\s+(?:21H\d|22H\d|23H\d|24H\d)\b",
+    r"\bOS Build\b|\bBuild\s+\d{4,}(?:\.\d+)?\b",
+    r"\bfailed\b|\berror\b|\bpending\b|\brestart required\b|\binstall now\b|\bpause updates\b",
+]
+
+# Max allowable age for Last checked / Installed on (days)
+MAX_LAST_CHECK_DAYS = int(os.environ.get("PATCH_OS_MAX_LAST_CHECK_DAYS", "14"))
+
+# Date parsing formats
+_DATE_FORMATS = [
+    "%d/%m/%Y", "%m/%d/%Y", "%Y-%m-%d",
+    "%d %b %Y", "%d %B %Y", "%b %d, %Y", "%B %d, %Y",
+    "%d-%m-%Y", "%m-%d-%Y",
+]
+_LAST_CHECK_RE   = re.compile(r"Last\s*checked\s*:?\s*([^\r\n]+)", re.I)
+_INSTALLED_ON_RE = re.compile(r"Installed\s*on\s*:?\s*([^\r\n]+)", re.I)
+
+# -------------------- helpers --------------------
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+def _resolve_evidence_dir() -> Path:
+    env = os.environ.get("PATCH_OS_DIR")
+    if env:
+        p = Path(env)
+        if p.exists():
+            return p
+    root = _project_root()
+    for c in [root / "evidence" / "patch_operating_systems",
+              root / "security" / "evidence" / "patch_operating_systems"]:
+        if c.exists():
+            return c
+    return root / "evidence" / "patch_operating_systems"
+
+def _iter_evidence_files(root: Path) -> Iterable[Path]:
+    if not root.exists():
+        return []
+    for p in sorted(root.iterdir()):
+        if p.is_file() and p.suffix.lower() in EXTS:
+            yield p
+
+def _ocr_image_bytes(data: bytes) -> str:
+    """OCR tuned for dark Windows Settings UI."""
+    if not pytesseract or not Image:
+        return ""
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            img = img.convert("L")
+            if ImageStat:
+                mean_luma = ImageStat.Stat(img).mean[0]
+                if mean_luma < 80:  # dark theme → invert
+                    img = ImageOps.invert(img)
+            img = ImageOps.autocontrast(img)
+            w, h = img.size
+            img = img.resize((int(w * 1.5), int(h * 1.5)))
+            if ImageFilter:
+                img = img.filter(ImageFilter.SHARPEN)
+            return pytesseract.image_to_string(img, config="--psm 6 --oem 3")
+    except UnidentifiedImageError:
+        return ""
+    except Exception:
+        return ""
+
+def _extract_text(path: Optional[Path]) -> str:
+    if not path:
+        return ""
+    s = path.suffix.lower()
+    try:
+        if s in {".txt", ".log"}:
+            return path.read_text(errors="ignore")
+        if s == ".pdf" and fitz:
+            out = []
+            with fitz.open(path) as doc:
+                for page in doc:
+                    out.append(page.get_text() or "")
+            return "\n".join(out)
+        if s == ".docx" and DocxDocument:
+            d = DocxDocument(str(path))
+            return "\n".join(p.text for p in d.paragraphs)
+        if s in {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".webp"}:
+            return _ocr_image_bytes(path.read_bytes())
+        return path.read_text(errors="ignore")
+    except Exception:
+        return ""
+
+def _matched_patterns(text: str) -> List[str]:
+    return [pat for pat in KEYWORDS if re.search(pat, text, re.I)]
+
+def _filename_hinted(name: str) -> bool:
+    low = name.lower()
+    return any(h in low for h in FILENAME_HINTS)
+
+def _parse_rel_or_fmt(token: str) -> Optional[datetime]:
+    token = token.strip()
+    now = datetime.now()
+    low = token.lower()
+    # support "Today, 3:27 PM" / "Yesterday, 10:15 AM"
+    if low.startswith("today"):
+        return now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if low.startswith("yesterday"):
+        d = now - timedelta(days=1)
+        return d.replace(hour=0, minute=0, second=0, microsecond=0)
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(token, fmt)
+        except Exception:
+            pass
+    m = re.search(r"\b(\d{1,2})\s+([A-Za-z]{3,})\s+(\d{4})\b", token)
+    if m:
+        for fmt in ("%d %B %Y", "%d %b %Y"):
+            try:
+                return datetime.strptime(m.group(0), fmt)
+            except Exception:
+                pass
+    return None
+
+def _extract_date_info(text: str) -> Tuple[Optional[str], Optional[str], Optional[int], str]:
+    """
+    Return (raw_label, iso_date, age_days, which_label) using Last checked OR Installed on (prefer Last checked).
+    """
+    now = datetime.now()
+    raw = iso = None
+    age_days = None
+    which = ""
+
+    m = _LAST_CHECK_RE.search(text)
+    if not m:
+        m = _INSTALLED_ON_RE.search(text)
+        which = "Installed on" if m else ""
+    else:
+        which = "Last checked"
+
+    if m:
+        raw_val = m.group(1).strip()
+        dt = _parse_rel_or_fmt(raw_val)
+        if dt:
+            iso = dt.strftime("%Y-%m-%d")
+            age_days = (now.date() - dt.date()).days
+        raw = raw_val
+    return raw, iso, age_days, which
+
+def _has_failure_indicators(text: str) -> bool:
+    return bool(re.search(r"\b(failed|error|pending|restart required|install now|pause updates)\b", text, re.I))
+
+def _pass_signal(text: str, fname: str, age_days: Optional[int]) -> bool:
+    """
+    PASS if:
+      - "You're up to date" AND date age <= threshold, OR
+      - KB/update or Build/Version evidence AND filename hint AND date age <= threshold.
+    """
+    up_to_date = re.search(r"\bYou'?re up to date\b", text, re.I) is not None
+    kb_or_update = re.search(r"\b(KB\d{6,}|(Cumulative|Feature)\s+update)\b", text, re.I)
+    build_or_ver = re.search(r"\b(OS Build|Version\s+(?:21H\d|22H\d|23H\d|24H\d)|Windows (10|11))\b", text, re.I)
+
+    if up_to_date and age_days is not None:
+        return age_days <= MAX_LAST_CHECK_DAYS
+    if (kb_or_update or build_or_ver) and _filename_hinted(fname) and age_days is not None:
+        return age_days <= MAX_LAST_CHECK_DAYS
+    return False
+
+# -------- core builder --------
+def _build_hit_for_text(ev_text: str, ev_name: str, ev_path: Optional[Path]) -> Dict[str, Any] | None:
+    patterns = _matched_patterns(ev_text)
+    hinted   = _filename_hinted(ev_name)
+    if not (patterns or hinted):
+        return None
+
+    raw_date, iso_date, age_days, which_label = _extract_date_info(ev_text)
+    passed = _pass_signal(ev_text, ev_name, age_days)
+    fail_indicators = _has_failure_indicators(ev_text)
+
+    # ---- Level/priority/recommendation ----
+    level = "ML1"  # <-- fixed per requirement
+    stale_or_missing = (age_days is None) or (age_days > MAX_LAST_CHECK_DAYS)
+    priority = "P2" if (stale_or_missing or fail_indicators or not passed) else "P4"
+
+    base_rec = (
+        f"Maintain OS update/build evidence. Ensure Windows Update checks are recent (≤ {MAX_LAST_CHECK_DAYS} days). "
+        "For ML1 timelines: apply critical/weaponised updates within 48h; apply other updates within 2 weeks for online "
+        "services and within 1 month for other applications; remove unsupported OS versions."
+    )
+    fix_rec = (
+        " Turn on automatic Windows Update (Settings → Windows Update), keep “Get the latest updates as soon as they’re "
+        "available” enabled, click “Check for updates”, and schedule required restarts. Ensure the Windows Update service "
+        "is running and updates are not paused."
+    )
+    recommendation = base_rec + ("" if passed and not stale_or_missing and not fail_indicators else fix_rec)
+
+    return {
+        "test_id": "E8-POS-ML1-001",
+        "sub_strategy": "Patch Operating Systems — Update/Build Evidence (Date-Checked)",
+        "detected_level": level,                       # <-- ML1
+        "pass_fail": "pass" if passed else "fail",
+        "priority": priority,
+        "recommendation": recommendation,
+        "evidence": {
+            "source_file": ev_name,
+            "absolute_path": str(ev_path) if ev_path else "",
+            "filename_hinted": hinted,
+            "keyword_patterns_matched": patterns,
+            "date_field_used": which_label or "",
+            "last_checked_raw": raw_date,
+            "last_checked_iso": iso_date,
+            "last_checked_age_days": age_days,
+            "max_last_check_days": MAX_LAST_CHECK_DAYS,
+            "up_to_date_string_found": bool(re.search(r"\bYou'?re up to date\b", ev_text, re.I)),
+            "failure_indicators_found": fail_indicators,
+        },
+    }
+
+# -------------------- Strategy --------------------
+class PatchOperatingSystemsML1(Strategy):
+    name = "Patch Operating Systems (ML1)"
+    key  = "patch_operating_systems_ml1"
+    EVIDENCE_DIR = _resolve_evidence_dir()
+
     def description(self) -> str:
-        return "To be described"
+        return (
+            "Validates Windows Update status and recency of 'Last checked/Installed on'. "
+            "Pass requires up-to-date state with a recent check (≤ threshold). Level = ML1. "
+            "Supports single-file uploads and folder scans."
+        )
+
+    def emit_hits(self, text: str = "", source_file: str = "", **kwargs) -> List[Dict[str, Any]]:
+        hits: List[Dict[str, Any]] = []
+
+        # ---- SINGLE-FILE MODE (UI upload) ----
+        if source_file:
+            ev_path: Optional[Path] = None
+            fp = kwargs.get("full_path")
+            if fp:
+                try:
+                    ev_path = Path(fp)
+                except Exception:
+                    ev_path = None
+            ev_text = text or (_extract_text(ev_path) if ev_path and ev_path.exists() else "")
+            h = _build_hit_for_text(ev_text, source_file, ev_path)
+            return [h] if h else []
+
+        # ---- FOLDER MODE ----
+        for ev_path in _iter_evidence_files(self.EVIDENCE_DIR):
+            ev_text = _extract_text(ev_path)
+            h = _build_hit_for_text(ev_text, ev_path.name, ev_path)
+            if h:
+                hits.append(h)
+
+        return hits


### PR DESCRIPTION
	
### Patch Applications (ML1) - Winget Pending Updates
<img width="935" height="413" alt="winget_upgrade" src="https://github.com/user-attachments/assets/8da69870-8110-4a1a-9f1c-265323d0032f" />
 
**Objective**

- Provide auditable proof that endpoint applications are kept up to date by detecting pending updates from winget upgrade output across many devices. Aligns with ML1 timelines.

**Detection** logic

1. Locate evidence

Folder: <repo>\evidence\patch_applications\ (override with PATCH_APPLICATIONS_DIR).
Types: .txt .log .pdf .docx .png .jpg .jpeg .bmp .tif .tiff .webp.

2. Recognise winget output
Filename hints: winget_upgrade, winget-upgrade, winget upgrades, winget upg, winget upgrade, or
Text cues: contains winget and a header with Name/Package, Version, Available.

3. Extract text
o	TXT/PDF/DOCX parsed natively.
o	Images OCR’d with Tesseract. Dark-theme preproc: grayscale → invert if dark → autocontrast → 1.5× upsample → light sharpen.

4. Parse table
o	Find the header, then split rows on 2+ spaces into Name | Id | Version | Available | Source.
o	Deduplicate by (Name, Available).

5. Fail-safe footer
o	If parsing returns 0 rows but the text contains “X upgrades available.”, set pending_count = X and FAIL.

6. Critical-app boosting
o	If any row mentions: Edge/Chrome/Firefox, Teams/Zoom/Slack, Java/Temurin/OpenJDK, Node.js, Python 3, 7-Zip/WinRAR, Adobe Acrobat/Reader, VLC, Wireshark, PuTTY, mark as Priority P2 (Level still ML1).

**Pass / Fail criteria**
•	PASS:
“No updates found/available” phrase present or parsed table has 0 rows and no footer count.
•	FAIL:
Any pending rows parsed, or footer shows X upgrades available.

Report row mapping
•	Test ID: E8-PA-ML1-001
•	Sub-Strategy: Patch Applications - Winget Pending Updates
•	Level: ML1 (fixed)
•	Status: pass / fail
•	Priority: P2 if any critical app pending, else P4
•	Recommendation (FAIL):
“Prioritize updating critical apps immediately (browsers, collaboration tools, runtimes). Run winget upgrade --all --silent --accept-source-agreements --accept-package-agreements or deploy via Intune/SCCM to all devices. Enforce auto-update policies for browsers and high-risk apps. Prefer stable/LTS channels where applicable. For ML1 timelines: remediate critical/weaponised within 48h; other non-critical within 2 weeks.”
•	Recommendation (PASS):
“Maintain evidence; keep auto-updates enforced.”

**How to collect evidence (per device)**
•	TXT (preferred): winget upgrade > %USERPROFILE%\Desktop\winget_upgrade.txt
•	Screenshot: terminal result as winget_upgrade.png
**Implementation notes**
•	Avoid duplicates: only one PatchApplicationsML1 class in security\strategies\.
•	Supports single-file runner calls via emit_hits(text=..., source_file=..., full_path=...).

### Patch Operating Systems (ML1) - Windows Update Recency
 
<img width="1194" height="770" alt="winupdate_home" src="https://github.com/user-attachments/assets/48dda157-2dfb-4ba1-b8c5-93a585b39bef" />

**Objective**
Prove OS patching discipline by validating Windows Update status and the recency of Last checked / Installed on against an ML1 threshold (default 14 days).

**Detection logic**
1. Locate evidence
Folder: <repo>\evidence\patch_operating_systems\ (override PATCH_OS_DIR).
Types: .png .jpg .jpeg .bmp .tif .tiff .webp .pdf .docx .txt .log.
Single-file uploads supported (text, source_file, full_path).

2. Extract text
TXT/LOG/PDF/DOCX parsed natively; images OCR’d with the same dark-UI preproc.

3. Recognise OS evidence
o Keywords: Windows Update, You're up to date, Last checked, Installed on, Check for updates, KB\d+, Cumulative update, Feature update, Windows 10/11, Version 21H*/22H*/23H*/24H*, OS Build, Build \d+, and failure words: failed, error, pending, restart required, install now, pause updates.
o Filename hints: winupdate_home, winupdate_history, system_about, settings_about, os_build, winver, update_status.

4. Parse the date
Prefer Last checked:, else Installed on:.
Understands Today, Yesterday, common formats (dd/mm/yyyy, mm/dd/yyyy, yyyy-mm-dd, 28 Aug 2025, …).
Computes age in days vs PATCH_OS_MAX_LAST_CHECK_DAYS (default 14).

5. Decide pass/fail
o	PASS:
“You’re up to date” and age ≤ threshold, or clear KB/update/build evidence and age ≤ threshold (with a filename hint).
o	FAIL:
age missing or > threshold, or failure words present, or no strong update/build evidence with a recent date.

**Report row mapping**
•	Test ID: E8-POS-ML1-001
•	Sub-Strategy: Patch Operating Systems — Update/Build Evidence (Date-Checked)
•	Level: ML1 (fixed)
•	Status: pass / fail
•	Priority: P2 if stale/missing/failed, else P4
•	Recommendation (FAIL):
“Maintain OS update/build evidence. Ensure Windows Update checks are recent (≤ {threshold} days). Turn on automatic Windows Update (Settings → Windows Update), keep ‘Get the latest updates as soon as they’re available’ enabled, click ‘Check for updates’, and schedule required restarts. Ensure the Windows Update service is running and updates are not paused. For ML1 timelines: apply critical/weaponised updates within 48h; apply other updates within 2 weeks for online services and within 1 month for other applications; remove unsupported OS versions.”
•	Recommendation (PASS):
“Maintain OS update/build evidence. Ensure Windows Update checks remain recent (≤ {threshold} days). For ML1 timelines: apply critical/weaponized within 48h; other updates within 2 weeks (online services) / 1 month (others).”

**How to collect evidence (per device)**
•	Windows Update home: Settings → Windows Update (shows “You’re up to date” and “Last checked”) → winupdate_home.png
•	Update history: Settings → Windows Update → Update history → winupdate_history.png

**Implementation notes**
•	Level: fixed ML1.
•	Priority: P2 on stale/missing/failed, else P4.
•	Threshold: setx PATCH_OS_MAX_LAST_CHECK_DAYS 14 (or another value).
•	Avoid duplicates: only one OS strategy inheriting Strategy in security\strategies\.
•	Dark theme: OCR preproc handles the dark Settings UI.
•	Single-file uploads: emit_hits(text=..., source_file=..., full_path=...) is supported.

