### PR TITLE
The initial Rule Schema v1 under engine/rules/schema/rule_schema_v1.j…

### DIFF
--- a/engine/rules/schema/rule_schema_v1.json
+++ b/engine/rules/schema/rule_schema_v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Compliance Rule Schema v1",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the rule (e.g., CIS-1.1.1)"
+    },
+    "title": {
+      "type": "string",
+      "description": "Short title of the compliance rule"
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed explanation of the compliance requirement"
+    },
+    "frameworks": {
+      "type": "object",
+      "description": "Mappings to multiple frameworks",
+      "additionalProperties": { "type": "string" }
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "weight": {
+      "type": "number",
+      "minimum": 0
+    },
+    "check_type": {
+      "type": "string",
+      "enum": ["graph_query", "regex", "boolean", "custom", "opa"]
+    },
+    "query": {
+      "type": "string",
+      "description": "Graph API endpoint, regex pattern, or OPA policy reference"
+    },
+    "expected_value": {
+      "description": "The expected outcome of the check",
+      "type": ["string", "boolean", "object", "array", "number"]
+    }
+  },
+  "required": ["id", "title", "description", "severity", "weight", "check_type"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
…son.

Defines a standard JSON Schema for compliance rules across all frameworks (CIS, NIST, ISO, ASD, MITRE).

Ensures each rule JSON has consistent structure, including required fields:

id, title, description, severity, weight, check_type

Optional fields: frameworks, query, expected_value

Enables future rule validation and backward compatibility as new frameworks are integrated.

Why this change

Provides a foundation for policy-as-code compliance rules.

Reduces risk of malformed rule definitions.

Ensures all compliance frameworks (CIS, NIST, ISO, ASD, MITRE) can be mapped under one schema.