### PR TITLE
Introduce framework_mapper.py for multi-framework compliance mapping

### DIFF
--- a/engine/engine/framework_mapper.py
+++ b/engine/engine/framework_mapper.py
@@ -1,0 +1,28 @@
+"""
+Maps rules to compliance frameworks using a mapping table.
+"""
+import json
+ 
+def load_mapping_table(path="data/framework_crosswalk.json"):
+    with open(path, "r") as f:
+        return json.load(f)
+ 
+def map_rule_to_frameworks(rule_dict, mapping_table):
+    matched_controls = []
+    for framework, control_ids in mapping_table.items():
+        for control in control_ids:
+            if control.lower() in json.dumps(rule_dict).lower():
+                matched_controls.append({"framework": framework, "control": control})
+    return matched_controls
+ 
+def enrich_rule_with_frameworks(rule_path, mapping_table):
+    with open(rule_path, "r") as f:
+        rule_data = json.load(f)
+    rule_data["frameworks"] = map_rule_to_frameworks(rule_data, mapping_table)
+    return rule_data
+ 
+# Example usage
+if __name__ == '__main__':
+    mapping = load_mapping_table()
+    enriched = enrich_rule_with_frameworks("data/sample_rule.json", mapping)
+    print(json.dumps(enriched, indent=2))


### PR DESCRIPTION
This commit introduces a new engine module `framework_mapper.py` designed to map audit rules to relevant compliance frameworks such as CIS, NIST, and ISO 27001.

Key features:

- Loads a compliance control crosswalk file (JSON format)
- Parses rule content and identifies framework control matches
- Appends matched frameworks and control IDs to the rule dictionary
- Outputs enriched rule data with added compliance metadata

This supports multi-framework mapping for the same rule, enabling better traceability, dashboard visualization, and compliance reporting. It serves as a foundation for evidence collection and automated mapping to multiple benchmarks.
