### PR TITLE
Updated navigation UI

### DIFF
--- a/frontend/src/pages/Auth/LoginPage.jsx
+++ b/frontend/src/pages/Auth/LoginPage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./LoginPage.css";
 import "../Landing/LandingPage.css";
-import LoginHeader from "./components/LoginHeader";
+import LandingHeader from "../Landing/components/LandingHeader";
 import BrandPanel from "./components/BrandPanel";
 import SignInPanel from "./components/SignInPanel";
 import LandingFooter from "../Landing/components/LandingFooter";
@@ -9,7 +9,7 @@ import LandingFooter from "../Landing/components/LandingFooter";
 const LoginPage = ({ onLogin, onSignUpClick }) => {
   return (
     <div className="login-page">
-      <LoginHeader />
+      <LandingHeader />
       <main className="login-main">
         <BrandPanel />
         <SignInPanel onLogin={onLogin} onSignUpClick={onSignUpClick} />

--- a/frontend/src/pages/Auth/SignUpPage.jsx
+++ b/frontend/src/pages/Auth/SignUpPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import "./LoginPage.css";
 import "./SignUpPage.css";
-import LoginHeader from "./components/LoginHeader";
+import LandingHeader from "../Landing/components/LandingHeader";
 import LandingFooter from "../Landing/components/LandingFooter";
 import SignupBrandPanel from "./components/SignupBrandPanel";
 import SignupFormPanel from "./components/SignupFormPanel";
@@ -50,7 +50,7 @@ export default function SignUpPage({ onSignUp, onBackToLogin }) {
 
   return (
     <div className="login-page signup-page">
-      <LoginHeader />
+      <LandingHeader />
       <main className="login-main signup-main">
         <SignupBrandPanel />
         <SignupFormPanel

--- a/frontend/src/pages/Contact/ContactPage.jsx
+++ b/frontend/src/pages/Contact/ContactPage.jsx
@@ -9,58 +9,61 @@ import FAQSection from "./components/FAQSection";
 import { createContactSubmission } from "../../api/client";
 
 const ContactHero = () => (
-  <section className="contact-hero" id="home">
-    <div className="contact-hero-content">
-      <p className="section-tag">Contact AutoAudit</p>
-      <h1>Get in Touch</h1>
-      <p>
-        Have questions about AutoAudit? Our team is here to help. Reach out and
-        we&apos;ll respond as soon as possible.
-      </p>
-    </div>
-  </section>
+	<section className="contact-hero" id="home">
+		<div className="contact-hero-content">
+			<p className="section-tag">Contact AutoAudit</p>
+			<h1>Get in Touch</h1>
+			<p>
+				Have questions about AutoAudit? Our team is here to help. Reach
+				out and we&apos;ll respond as soon as possible.
+			</p>
+		</div>
+	</section>
 );
 
 const ContactPage = ({ onSignIn }) => {
-  const [submitted, setSubmitted] = useState(false);
+	const [submitted, setSubmitted] = useState(false);
 
-  const handleFormSuccess = () => {
-    setSubmitted(true);
-    setTimeout(() => setSubmitted(false), 5000);
-  };
+	const handleFormSuccess = () => {
+		setSubmitted(true);
+		setTimeout(() => setSubmitted(false), 5000);
+	};
 
-  const handleSubmit = async (payload) => {
-    await createContactSubmission({
-      first_name: payload.firstName,
-      last_name: payload.lastName,
-      email: payload.email,
-      phone: payload.phone || null,
-      company: payload.company || null,
-      subject: payload.subject,
-      message: payload.message,
-      source: "website",
-    });
-    handleFormSuccess();
-  };
+	const handleSubmit = async (payload) => {
+		await createContactSubmission({
+			first_name: payload.firstName,
+			last_name: payload.lastName,
+			email: payload.email,
+			phone: payload.phone || null,
+			company: payload.company || null,
+			subject: payload.subject,
+			message: payload.message,
+			source: "website",
+		});
+		handleFormSuccess();
+	};
 
-  return (
-    <div className="contact-page">
-      <LandingHeader onSignInClick={onSignIn} hiddenLinks={["Contact"]} />
-      <main>
-        <ContactHero />
+	return (
+		<div className="contact-page">
+			<LandingHeader onSignInClick={onSignIn} />
+			<main>
+				<ContactHero />
 
-        <section className="contact-section" id="features">
-          <div className="contact-container">
-            <ContactInfoGrid />
-            <ContactForm submitted={submitted} onSubmit={handleSubmit} />
-          </div>
-        </section>
+				<section className="contact-section" id="features">
+					<div className="contact-container">
+						<ContactInfoGrid />
+						<ContactForm
+							submitted={submitted}
+							onSubmit={handleSubmit}
+						/>
+					</div>
+				</section>
 
-        <FAQSection />
-      </main>
-      <LandingFooter />
-    </div>
-  );
+				<FAQSection />
+			</main>
+			<LandingFooter />
+		</div>
+	);
 };
 
 export default ContactPage;

--- a/frontend/src/pages/Landing/AboutUs.jsx
+++ b/frontend/src/pages/Landing/AboutUs.jsx
@@ -56,7 +56,7 @@ const standards = [
 const AboutUs = ({ onSignInClick = () => {} }) => {
   return (
     <div className="about-page">
-      <LandingHeader onSignInClick={onSignInClick} hiddenLinks={["About"]} />
+      <LandingHeader onSignInClick={onSignInClick} />
 
       <main>
         <section className="about-hero" id="home">

--- a/frontend/src/pages/Landing/LandingPage.css
+++ b/frontend/src/pages/Landing/LandingPage.css
@@ -19,7 +19,6 @@
   color: var(--text-main);
   background: var(--bg-dark);
   min-height: 100vh;
-  overflow-x: hidden;
 }
 
 .landing-page * {
@@ -70,7 +69,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 5%;
+  padding: 0.5rem 5%;
   background: rgba(10, 22, 40, 0.95);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
@@ -177,9 +176,10 @@
 /* Hero */
 .landing-hero {
   background: var(--bg-gradient);
-  padding: 6rem 5% 4rem;
+  padding: 1rem 5% 4rem;
   position: relative;
   isolation: isolate;
+  overflow: hidden;
 }
 
 .landing-hero::before,
@@ -189,6 +189,7 @@
   border-radius: 50%;
   opacity: 0.9;
   z-index: -1;
+  overflow: hidden;
 }
 
 .landing-hero::before {


### PR DESCRIPTION
Main changes:
- Fixed navbar sticky property
- Disabled hiding of corresponding page link in navbar

Before: 
<img width="1892" height="966" alt="navbar-before" src="https://github.com/user-attachments/assets/0a2a2baf-9dae-4714-b1cf-65c87b62b570" />

After:
<img width="1893" height="920" alt="navbar-after" src="https://github.com/user-attachments/assets/94300249-d8da-4de3-bf60-708590f356a0" />

Sticky property of navigation bar fixed, navigation bar can be used when scrolling down.

---

Before:
<img width="1895" height="902" alt="about-before" src="https://github.com/user-attachments/assets/0bb68bc9-c6d4-452d-be0c-612b332e4a24" />

After:
<img width="1892" height="965" alt="about-after" src="https://github.com/user-attachments/assets/0d5b11d5-a926-4332-ae59-9a64fe03ebfd" />

"About" link is still visible when on About page. This is more intuitive and reduces layout shift on page navigation.