### PR TITLE
Password strength indicator

### DIFF
--- a/frontend/src/pages/Auth/LoginPage.css
+++ b/frontend/src/pages/Auth/LoginPage.css
@@ -379,10 +379,10 @@
 
 .btn-signin {
   width: 100%;
-  padding: 1rem;
+  padding: 0.9rem;
   border-radius: 12px;
-  border: none;
-  background-image: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border: 2px solid rgba(59, 130, 246, 0.2);
+  background: rgba(255, 255, 255, 0.04);
   color: #ffffff;
   font-size: 1rem;
   font-weight: 600;
@@ -391,12 +391,12 @@
   justify-content: center;
   gap: 0.5rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
 .btn-signin:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+  border-color: var(--accent);
 }
 
 .divider {

--- a/frontend/src/pages/Auth/SignUpPage.css
+++ b/frontend/src/pages/Auth/SignUpPage.css
@@ -167,6 +167,43 @@
   background: var(--accent-strong);
 }
 
+/* Password strength indicator */
+.password-strength {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.password-strength-bars {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+
+.password-strength-bar {
+  height: 4px;
+  flex: 1;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.password-strength-bar.level-1 { background: #ef4444; }
+.password-strength-bar.level-2 { background: #f97316; }
+.password-strength-bar.level-3 { background: #eab308; }
+.password-strength-bar.level-4 { background: #22c55e; }
+
+.password-strength-label {
+  font-size: 0.78rem;
+  min-width: 40px;
+  text-align: right;
+}
+
+.password-strength-label.level-1 { color: #ef4444; }
+.password-strength-label.level-2 { color: #f97316; }
+.password-strength-label.level-3 { color: #eab308; }
+.password-strength-label.level-4 { color: #22c55e; }
+
 .social-login .social-btn {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Auth/components/SignupFormPanel.jsx
+++ b/frontend/src/pages/Auth/components/SignupFormPanel.jsx
@@ -62,6 +62,19 @@ const socialButtons = [
   },
 ];
 
+const getPasswordStrength = (password) => {
+  if (!password) return null;
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (/[A-Z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+  if (score <= 1) return { label: "Weak", level: 1 };
+  if (score <= 2) return { label: "Fair", level: 2 };
+  if (score <= 3) return { label: "Good", level: 3 };
+  return { label: "Strong", level: 4 };
+};
+
 const SignupFormPanel = ({ formData, onFormChange, onSubmit, onBackToLogin, submitError }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -194,6 +207,25 @@ const SignupFormPanel = ({ formData, onFormChange, onSubmit, onBackToLogin, subm
                 {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
               </button>
             </div>
+            {(() => {
+              const strength = getPasswordStrength(formData.password);
+              if (!strength) return null;
+              return (
+                <div className="password-strength">
+                  <div className="password-strength-bars">
+                    {[1, 2, 3, 4].map((i) => (
+                      <div
+                        key={i}
+                        className={`password-strength-bar ${i <= strength.level ? `level-${strength.level}` : ""}`}
+                      />
+                    ))}
+                  </div>
+                  <span className={`password-strength-label level-${strength.level}`}>
+                    {strength.label}
+                  </span>
+                </div>
+              );
+            })()}
           </label>
 
           <label className="signup-field">

--- a/frontend/src/pages/Auth/components/SignupFormPanel.jsx
+++ b/frontend/src/pages/Auth/components/SignupFormPanel.jsx
@@ -64,14 +64,16 @@ const socialButtons = [
 
 const getPasswordStrength = (password) => {
   if (!password) return null;
+  // length is a hard gate — short passwords can't score high regardless of complexity
+  if (password.length < 6) return { label: "Weak", level: 1 };
   let score = 0;
-  if (password.length >= 8) score++;
+  if (password.length >= 10) score++;
   if (/[A-Z]/.test(password)) score++;
   if (/[0-9]/.test(password)) score++;
   if (/[^A-Za-z0-9]/.test(password)) score++;
   if (score <= 1) return { label: "Weak", level: 1 };
-  if (score <= 2) return { label: "Fair", level: 2 };
-  if (score <= 3) return { label: "Good", level: 3 };
+  if (score === 2) return { label: "Fair", level: 2 };
+  if (score === 3) return { label: "Good", level: 3 };
   return { label: "Strong", level: 4 };
 };
 


### PR DESCRIPTION
![Image 24-03-26 at 11 55 AM](https://github.com/user-attachments/assets/ee9e3bb8-6a2e-49f9-bce4-9265ea97c70f)
![Image 24-03-26 at 11 56 AM](https://github.com/user-attachments/assets/40a4009c-3d57-4d4f-a2b5-07ec1943c4ba)
![Image 24-03-26 at 12 23 PM](https://github.com/user-attachments/assets/1b864fa4-b0e1-4dab-8e03-78f6987b7ea9)
![Image 24-03-26 at 11 57 AM](https://github.com/user-attachments/assets/cbf2efeb-2a5e-447f-babe-23a9f1ca2730)
Added a visual password strength indicator to the Create Account form so users get real-time feedback as they type their password. Added a getPasswordStrength helper that scores the password based on length, uppercase, numbers, and special characters, returning one of four levels: Weak, Fair, Good, Strong
The strength bar appears below the password field as soon as the user starts typing and disappears when the field is empty
Each level has a distinct color — red, orange, yellow, green — so it's immediately clear at a glance
Also updated the "Create Account" button styling to match the Google sign-up button for visual consistency (same border, padding, and background)