### PR TITLE
26T1-IMP-DHA-002 Implement tenant_id validation including unit tests

### DIFF
--- a/engine/collectors/powershell_client.py
+++ b/engine/collectors/powershell_client.py
@@ -68,7 +68,7 @@ class PowerShellClient:
         self._msal_app = ConfidentialClientApplication(
             client_id=client_id,
             client_credential=client_secret,
-            authority=f"https://login.microsoftonline.com/{tenant_id}",
+            authority=f"https://login.microsoftonline.com/{self.tenant_id}",
         )
         self._image_checked = False
 

--- a/engine/collectors/powershell_client.py
+++ b/engine/collectors/powershell_client.py
@@ -26,6 +26,8 @@ from typing import Any
 import httpx
 from msal import ConfidentialClientApplication
 
+from worker.validators import validate_tenant_id
+
 
 class PowerShellExecutionError(Exception):
     """Raised when PowerShell execution fails."""
@@ -59,7 +61,7 @@ class PowerShellClient:
             service_url: Optional URL of PowerShell HTTP service (e.g., http://powershell-service:8001).
                          If provided, uses HTTP instead of spawning Docker containers.
         """
-        self.tenant_id = tenant_id
+        self.tenant_id = validate_tenant_id(tenant_id)
         self.client_id = client_id
         self.client_secret = client_secret
         self.service_url = service_url

--- a/engine/powershell/service/executor.py
+++ b/engine/powershell/service/executor.py
@@ -2,8 +2,42 @@
 
 import json
 import os
+import re
 import subprocess
 from typing import Any, Dict, Optional
+
+# NOTE: This validation function is duplicated in engine/worker/validators.py
+# because the powershell service is an isolated package. Keep both copies in sync.
+
+_TENANT_ID_GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# Labels allow alphanumeric + hyphens; TLD must be alpha-only (2+ chars)
+_TENANT_ID_DOMAIN_RE = re.compile(
+    r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?"
+    r"(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*"
+    r"\.[a-zA-Z]{2,}$"
+)
+
+
+def validate_tenant_id(value: str) -> str:
+    """Validate that a tenant_id is a GUID or domain name.
+
+    Prevents PowerShell command injection by ensuring the value contains
+    only characters that are structurally safe for interpolation.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("tenant_id must not be empty")
+    if _TENANT_ID_GUID_RE.match(stripped) or _TENANT_ID_DOMAIN_RE.match(stripped):
+        return stripped
+    raise ValueError(
+        f"Invalid tenant_id format: {stripped!r}. "
+        "Must be a GUID (e.g. 12345678-1234-1234-1234-123456789abc) "
+        "or a domain name (e.g. contoso.onmicrosoft.com)."
+    )
 
 
 class PowerShellExecutionError(Exception):
@@ -51,6 +85,7 @@ def build_script(
     Returns:
         PowerShell script as a string
     """
+    tenant_id = validate_tenant_id(tenant_id)
     param_str = build_param_string(params)
 
     if module == "ExchangeOnline":

--- a/engine/powershell/service/schemas.py
+++ b/engine/powershell/service/schemas.py
@@ -2,7 +2,9 @@
 
 from typing import Any, Dict, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from executor import validate_tenant_id
 
 
 class ExecuteRequest(BaseModel):
@@ -18,7 +20,12 @@ class ExecuteRequest(BaseModel):
         default_factory=dict,
         description="Parameters to pass to the cmdlet",
     )
-    tenant_id: str = Field(description="Azure AD tenant ID")
+    tenant_id: str = Field(description="Azure AD tenant ID (GUID or verified domain)")
+
+    @field_validator("tenant_id")
+    @classmethod
+    def check_tenant_id_format(cls, v: str) -> str:
+        return validate_tenant_id(v)
     token: str = Field(description="Access token for Exchange/Compliance")
     graph_token: Optional[str] = Field(
         default=None,

--- a/engine/tests/test_validators.py
+++ b/engine/tests/test_validators.py
@@ -1,0 +1,79 @@
+"""Tests for tenant_id validation (PowerShell command injection prevention)."""
+
+import pytest
+
+from worker.validators import validate_tenant_id
+
+
+# -- Valid inputs: should return the stripped value without raising --
+
+VALID_TENANT_IDS = [
+    # GUIDs
+    ("12345678-1234-1234-1234-123456789abc", "12345678-1234-1234-1234-123456789abc"),
+    ("ABCDEF01-2345-6789-ABCD-EF0123456789", "ABCDEF01-2345-6789-ABCD-EF0123456789"),
+    ("aAbBcCdD-1234-5678-9012-eEfF00112233", "aAbBcCdD-1234-5678-9012-eEfF00112233"),
+    # GUIDs with surrounding whitespace (should be stripped)
+    ("  12345678-1234-1234-1234-123456789abc  ", "12345678-1234-1234-1234-123456789abc"),
+    # Domain names
+    ("contoso.onmicrosoft.com", "contoso.onmicrosoft.com"),
+    ("tenant.contoso.com", "tenant.contoso.com"),
+    ("example.co", "example.co"),
+    ("my-tenant.onmicrosoft.com", "my-tenant.onmicrosoft.com"),
+    ("sub1.sub2.example.com", "sub1.sub2.example.com"),
+    # Domain with surrounding whitespace
+    ("  contoso.onmicrosoft.com  ", "contoso.onmicrosoft.com"),
+]
+
+
+@pytest.mark.parametrize("input_val,expected", VALID_TENANT_IDS)
+def test_valid_tenant_id(input_val: str, expected: str) -> None:
+    assert validate_tenant_id(input_val) == expected
+
+
+# -- Invalid inputs: should raise ValueError --
+
+INVALID_TENANT_IDS = [
+    # Empty / whitespace
+    "",
+    "   ",
+    # PowerShell injection via GUID breakout
+    '12345678-1234-1234-1234-123456789abc"; Remove-Mailbox',
+    # PowerShell injection via domain breakout
+    'contoso.com"; Remove-Mailbox -Identity admin -Confirm:$false; #',
+    # Semicolon injection
+    "contoso.com; whoami",
+    # PowerShell subexpression
+    '$(Invoke-Expression "bad")',
+    # Backtick injection
+    '`Invoke-Expression "bad"',
+    # Pipe injection
+    "valid.com | bad-command",
+    # Newline injection
+    "valid.com\nInvoke-Expression bad",
+    # GUID without hyphens
+    "12345678123412341234123456789abc",
+    # Partial GUID
+    "12345678-1234-1234-1234",
+    # GUID with extra segment
+    "12345678-1234-1234-1234-123456789abc-extra",
+    # Domain starting with hyphen
+    "-invalid.com",
+    # Domain ending with hyphen
+    "invalid-.com",
+    # Domain with single-char TLD
+    "invalid.c",
+    # Domain with underscore
+    "under_score.com",
+    # Domain with no TLD
+    "localhost",
+    # Bare special characters
+    '"',
+    "$",
+    ";",
+]
+
+
+@pytest.mark.parametrize("input_val", INVALID_TENANT_IDS)
+def test_invalid_tenant_id(input_val: str) -> None:
+    with pytest.raises(ValueError, match="tenant_id"):
+        validate_tenant_id(input_val)

--- a/engine/worker/validators.py
+++ b/engine/worker/validators.py
@@ -1,0 +1,49 @@
+"""Input validation for security-sensitive fields.
+
+NOTE: This validation function is duplicated in engine/powershell/service/executor.py
+because the powershell service is an isolated package. Keep both copies in sync.
+"""
+
+import re
+
+# Azure AD tenant ID: standard GUID format
+_TENANT_ID_GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# Azure AD tenant ID: verified domain name (e.g. contoso.onmicrosoft.com)
+# Labels allow alphanumeric + hyphens; TLD must be alpha-only (2+ chars)
+_TENANT_ID_DOMAIN_RE = re.compile(
+    r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?"
+    r"(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*"
+    r"\.[a-zA-Z]{2,}$"
+)
+
+
+def validate_tenant_id(value: str) -> str:
+    """Validate that a tenant_id is a GUID or domain name.
+
+    This prevents PowerShell command injection by ensuring the value
+    contains only characters that are structurally safe for interpolation
+    into script strings.
+
+    Args:
+        value: The tenant_id to validate.
+
+    Returns:
+        The stripped, validated tenant_id.
+
+    Raises:
+        ValueError: If the value does not match GUID or domain format.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("tenant_id must not be empty")
+    if _TENANT_ID_GUID_RE.match(stripped) or _TENANT_ID_DOMAIN_RE.match(stripped):
+        return stripped
+    raise ValueError(
+        f"Invalid tenant_id format: {stripped!r}. "
+        "Must be a GUID (e.g. 12345678-1234-1234-1234-123456789abc) "
+        "or a domain name (e.g. contoso.onmicrosoft.com)."
+    )


### PR DESCRIPTION
## Summary
This pull request addresses the most critical cause of the powershell service's command injection vulnerability. Prior to these changes, an attacker with direct access to the powershell service or database could hand-craft an invalid AAD/Entra Tenant ID, with the ability to execute arbitrary powershell commands. See the screenshots below for an example of what was possible and what the outcomes were.

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [x] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->
[Original research task](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fplan%2FlcHW9ElPMUK9pRly1LHeX8gABVGl%2Fview%2Fboard%2Ftask%2Fyjs8rJ--c0qE0MjL5Wq92MgAMSi4%22%7D)

[Implementation task](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fplan%2FlcHW9ElPMUK9pRly1LHeX8gABVGl%2Fview%2Fboard%2Ftask%2FGFHprKeL_ky5ignzT7__IcgAEUlI%22%7D)

An authenticated user who controls the `tenant_id` value stored during M365 connection setup could break out of the
  quoted string in the PowerShell script and execute arbitrary commands inside the Docker container that runs PowerShell
   — turning a read-only compliance scanner into a platform for data exfiltration or lateral movement. The fix ensures
  tenant_id can only contain characters that are structurally impossible to use for injection.

## Testing Done
<!-- What did you test and how? -->
- [x] Unit tests pass locally
- [x] Tested manually — describe how:
- [ ] No tests required — explain why:

I tested manually to confirm that there was indeed a vulnerability. I worked on unit tests to enforce validation plus performed the manual testing again after implementation to confirm the initial vulnerability had been mitigated.

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->
No negative implications as a result of this change. The command injection vulnerability that was present has been patched.

## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:

## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->

### Before
Screenshot of the original malicious request
<img width="947" height="299" alt="image" src="https://github.com/user-attachments/assets/c9f7b38b-7c94-4de0-9cee-d67305c965ab" />

Response from the powershell service after execution. Note HTTP 200 with a failed request including the error message
<img width="850" height="356" alt="image" src="https://github.com/user-attachments/assets/aa057c19-ec7a-436e-94e6-358e2489fc7d" />

Screenshot from a temporary HTTP server showing the command was executed
<img width="940" height="60" alt="image" src="https://github.com/user-attachments/assets/2b2319b3-7bd3-4751-9014-f840a659092a" />

### After
Screenshot while attempting the same malicious request as demonstrated earlier
<img width="1012" height="414" alt="image" src="https://github.com/user-attachments/assets/4a88d910-5d1a-4dd5-acb1-651114df7981" />
