### PR TITLE
26T1-BAC-TR-005 - Collector creation for SharePoint

### DIFF
--- a/engine/collectors/registry.py
+++ b/engine/collectors/registry.py
@@ -152,6 +152,13 @@ from collectors.compliance.report_submission_policy import (
     ReportSubmissionPolicyDataCollector,
 )
 
+# SharePoint
+from collectors.sharepoint.spo_tenant import SpoTenantDataCollector
+from collectors.sharepoint.spo_site import SpoSiteDataCollector
+from collectors.sharepoint.spo_sync_client_restriction import (
+    SpoSyncClientRestrictionDataCollector,
+)
+
 # Registry mapping data_collector_id to collector class
 DATA_COLLECTORS: dict[str, type[BaseDataCollector]] = {
     # Applications
@@ -220,6 +227,10 @@ DATA_COLLECTORS: dict[str, type[BaseDataCollector]] = {
     "exchange.transport.transport_rules": TransportRulesDataCollector,
     # Compliance
     "compliance.report_submission_policy": ReportSubmissionPolicyDataCollector,
+    # Sharepoint
+    "sharepoint.spo_tenant": SpoTenantDataCollector,
+    "sharepoint.spo_site": SpoSiteDataCollector,
+    "sharepoint.spo_sync_client_restriction": SpoSyncClientRestrictionDataCollector,
 }
 
 

--- a/engine/collectors/sharepoint/spo_site.py
+++ b/engine/collectors/sharepoint/spo_site.py
@@ -3,19 +3,10 @@
 CIS Microsoft 365 Foundations Benchmark Controls:
     v6.0.0: 7.2.4
 
-Connection Method: SharePoint REST API
-Authentication: Client secret via MSAL (access token)
+Connection Method: Microsoft Graph
+Authentication: Client secret via MSAL application permissions
 
-CAVEAT: Access token authentication has not been fully tested.
-    It should work, but needs verification during implementation. Certificate-based
-    authentication may be required instead of client secret authentication.
-
-NOTE: This collector uses SharePoint REST API instead of PowerShell because
-SharePoint Online PowerShell does not support client secret authentication.
-If certificate authentication is adopted in the future, this collector should
-be updated to use the Get-SPOSite cmdlet instead.
-
-REST Endpoints: /_api/site or SharePoint Admin API for site collections
+Graph Endpoints: GET /sites/getAllSites
 """
 
 from typing import Any
@@ -40,5 +31,29 @@ class SpoSiteDataCollector(BaseDataCollector):
             - onedrive_sites: OneDrive for Business sites
             - site_sharing_settings: Per-site sharing configurations
         """
-        # TODO: Implement collector
-        raise NotImplementedError("Collector not yet implemented")
+        tenant_settings = await client.get_tenant_settings()
+        sites = await client.search_sites()
+
+        onedrive_sites = [
+            site for site in sites if "-my.sharepoint.com/" in str(site.get("url", ""))
+        ]
+
+        return {
+            "sites": sites,
+            "onedrive_sites": onedrive_sites,
+            "site_sharing_settings": {
+                "sharepoint_sharing_capability": tenant_settings.get(
+                    "CoreSharingCapability",
+                    tenant_settings.get("SharingCapability"),
+                ),
+                "onedrive_sharing_capability": tenant_settings.get(
+                    "OneDriveSharingCapability"
+                ),
+                "core_default_share_link_scope": tenant_settings.get(
+                    "CoreDefaultShareLinkScope"
+                ),
+                "onedrive_default_share_link_scope": tenant_settings.get(
+                    "OneDriveDefaultShareLinkScope"
+                ),
+            },
+        }

--- a/engine/collectors/sharepoint/spo_site.py
+++ b/engine/collectors/sharepoint/spo_site.py
@@ -22,6 +22,14 @@ class SpoSiteDataCollector(BaseDataCollector):
     sharing settings for compliance evaluation.
     """
 
+    @staticmethod
+    def _first_present(data: dict[str, Any], *keys: str) -> Any:
+        """Return the first non-missing value from a set of possible keys."""
+        for key in keys:
+            if key in data:
+                return data[key]
+        return None
+
     async def collect(self, client: SharePointClient) -> dict[str, Any]:
         """Collect SPO site data.
 
@@ -42,18 +50,27 @@ class SpoSiteDataCollector(BaseDataCollector):
             "sites": sites,
             "onedrive_sites": onedrive_sites,
             "site_sharing_settings": {
-                "sharepoint_sharing_capability": tenant_settings.get(
+                "sharepoint_sharing_capability": self._first_present(
+                    tenant_settings,
+                    "sharingCapability",
+                    "coreSharingCapability",
+                    "SharingCapability",
                     "CoreSharingCapability",
-                    tenant_settings.get("SharingCapability"),
                 ),
-                "onedrive_sharing_capability": tenant_settings.get(
-                    "OneDriveSharingCapability"
+                "onedrive_sharing_capability": self._first_present(
+                    tenant_settings,
+                    "oneDriveSharingCapability",
+                    "OneDriveSharingCapability",
                 ),
-                "core_default_share_link_scope": tenant_settings.get(
-                    "CoreDefaultShareLinkScope"
+                "core_default_share_link_scope": self._first_present(
+                    tenant_settings,
+                    "coreDefaultShareLinkScope",
+                    "CoreDefaultShareLinkScope",
                 ),
-                "onedrive_default_share_link_scope": tenant_settings.get(
-                    "OneDriveDefaultShareLinkScope"
+                "onedrive_default_share_link_scope": self._first_present(
+                    tenant_settings,
+                    "oneDriveDefaultShareLinkScope",
+                    "OneDriveDefaultShareLinkScope",
                 ),
             },
         }

--- a/engine/collectors/sharepoint/spo_sync_client_restriction.py
+++ b/engine/collectors/sharepoint/spo_sync_client_restriction.py
@@ -3,19 +3,10 @@
 CIS Microsoft 365 Foundations Benchmark Controls:
     v6.0.0: 7.3.2
 
-Connection Method: SharePoint REST API
-Authentication: Client secret via MSAL (access token)
+Connection Method: Microsoft Graph
+Authentication: Client secret via MSAL application permissions
 
-CAVEAT: Access token authentication has not been fully tested.
-    It should work, but needs verification during implementation. Certificate-based
-    authentication may be required instead of client secret authentication.
-
-NOTE: This collector uses SharePoint REST API instead of PowerShell because
-SharePoint Online PowerShell does not support client secret authentication.
-If certificate authentication is adopted in the future, this collector should
-be updated to use the Get-SPOTenantSyncClientRestriction cmdlet instead.
-
-REST Endpoints: SharePoint Admin API for sync client restrictions
+Graph Endpoints: GET /admin/sharepoint/settings
 """
 
 from typing import Any
@@ -41,5 +32,13 @@ class SpoSyncClientRestrictionDataCollector(BaseDataCollector):
             - domain_guids_allowed: Allowed domain GUIDs for sync
             - excluded_file_extensions: File types excluded from sync
         """
-        # TODO: Implement collector
-        raise NotImplementedError("Collector not yet implemented")
+        restrictions = await client.get_sync_client_restriction()
+
+        return {
+            "sync_client_restrictions": restrictions,
+            "tenant_restriction_enabled": restrictions.get("TenantRestrictionEnabled"),
+            "block_mac_sync": restrictions.get("BlockMacSync"),
+            "domain_guids_allowed": restrictions.get("AllowedDomainList", []),
+            "excluded_file_extensions": restrictions.get("ExcludedFileExtensions", []),
+            "groove_block_option": restrictions.get("GrooveBlockOption"),
+        }

--- a/engine/collectors/sharepoint/spo_tenant.py
+++ b/engine/collectors/sharepoint/spo_tenant.py
@@ -1,21 +1,12 @@
 """SPO tenant collector.
 
 CIS Microsoft 365 Foundations Benchmark Controls:
-    v6.0.0: 7.2.1, 7.2.2, 7.2.3, 7.2.4, 7.2.5, 7.2.6, 7.2.7, 7.2.9, 7.2.10, 7.2.11, 7.3.1
+    v6.0.0: 7.2.1, 7.2.3, 7.2.4, 7.2.5, 7.2.6, 7.2.7, 7.2.8, 7.2.9, 7.2.10, 7.2.11, 7.3.1
 
-Connection Method: SharePoint REST API
-Authentication: Client secret via MSAL (access token)
+Connection Method: Microsoft Graph
+Authentication: Client secret via MSAL application permissions
 
-CAVEAT: Access token authentication has not been fully tested.
-    It should work, but needs verification during implementation. Certificate-based
-    authentication may be required instead of client secret authentication.
-
-NOTE: This collector uses SharePoint REST API instead of PowerShell because
-SharePoint Online PowerShell does not support client secret authentication.
-If certificate authentication is adopted in the future, this collector should
-be updated to use the Get-SPOTenant cmdlet instead.
-
-REST Endpoints: /_api/SPOTenant or SharePoint Admin API
+Graph Endpoints: GET /admin/sharepoint/settings
 """
 
 from typing import Any
@@ -31,6 +22,69 @@ class SpoTenantDataCollector(BaseDataCollector):
     sharing, authentication, guest access, and other configurations.
     """
 
+    @staticmethod
+    def _first_present(data: dict[str, Any], *keys: str) -> Any:
+        """Return the first non-missing value from a set of possible keys."""
+        for key in keys:
+            if key in data:
+                return data[key]
+        return None
+
+    @staticmethod
+    def _as_list(value: Any) -> list[Any]:
+        """Normalize SharePoint list-like fields to plain lists."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, str):
+            if not value.strip():
+                return []
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, dict) and isinstance(value.get("results"), list):
+            return value["results"]
+        return [value]
+
+    @staticmethod
+    def _as_bool(value: Any) -> bool | None:
+        """Normalize bool-like values from Graph/REST payloads."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes"}:
+                return True
+            if normalized in {"false", "0", "no"}:
+                return False
+        return None
+
+    @classmethod
+    def _prevent_external_users_from_resharing(cls, tenant_settings: dict[str, Any]) -> bool | None:
+        """Resolve guest resharing protection from direct or inverse field variants."""
+        direct_value = cls._first_present(
+            tenant_settings,
+            "PreventExternalUsersFromResharing",
+            "preventExternalUsersFromResharing",
+        )
+        direct_bool = cls._as_bool(direct_value)
+        if direct_bool is not None:
+            return direct_bool
+
+        inverse_value = cls._first_present(
+            tenant_settings,
+            "isResharingByExternalUsersEnabled",
+            "IsResharingByExternalUsersEnabled",
+        )
+        inverse_bool = cls._as_bool(inverse_value)
+        if inverse_bool is not None:
+            return not inverse_bool
+
+        return None
+
     async def collect(self, client: SharePointClient) -> dict[str, Any]:
         """Collect SPO tenant data.
 
@@ -38,10 +92,120 @@ class SpoTenantDataCollector(BaseDataCollector):
             Dict containing:
             - tenant_settings: Full tenant configuration
             - legacy_auth_protocols_enabled: Legacy auth status
-            - azure_ad_b2b_integration_enabled: B2B integration status
             - sharing_capability: External sharing capability
             - default_sharing_link_type: Default sharing link type
             - default_link_permission: Default link permission level
         """
-        # TODO: Implement collector
-        raise NotImplementedError("Collector not yet implemented")
+        tenant_settings = await client.get_tenant_settings()
+
+        return {
+            "tenant_settings": tenant_settings,
+            "legacy_auth_protocols_enabled": self._first_present(
+                tenant_settings,
+                "isLegacyAuthProtocolsEnabled",
+                "LegacyAuthProtocolsEnabled",
+                "legacyAuthProtocolsEnabled",
+            ),
+            "sharing_capability": self._first_present(
+                tenant_settings,
+                "SharingCapability",
+                "sharingCapability",
+                "CoreSharingCapability",
+                "coreSharingCapability",
+            ),
+            "onedrive_sharing_capability": self._first_present(
+                tenant_settings,
+                "OneDriveSharingCapability",
+                "oneDriveSharingCapability",
+            ),
+            "default_sharing_link_type": self._first_present(
+                tenant_settings,
+                "DefaultSharingLinkType",
+                "defaultSharingLinkType",
+                "CoreDefaultShareLinkScope",
+                "coreDefaultShareLinkScope",
+            ),
+            "default_link_permission": self._first_present(
+                tenant_settings,
+                "DefaultLinkPermission",
+                "defaultLinkPermission",
+                "DefaultShareLinkRole",
+                "defaultShareLinkRole",
+                "CoreDefaultShareLinkRole",
+                "coreDefaultShareLinkRole",
+            ),
+            "prevent_external_users_from_resharing": self._prevent_external_users_from_resharing(
+                tenant_settings
+            ),
+            "sharing_domain_restriction_mode": self._first_present(
+                tenant_settings,
+                "SharingDomainRestrictionMode",
+                "sharingDomainRestrictionMode",
+            ),
+            "sharing_allowed_domain_list": self._as_list(
+                self._first_present(
+                    tenant_settings,
+                    "SharingAllowedDomainList",
+                    "sharingAllowedDomainList",
+                )
+            ),
+            "sharing_blocked_domain_list": self._as_list(
+                self._first_present(
+                    tenant_settings,
+                    "SharingBlockedDomainList",
+                    "sharingBlockedDomainList",
+                )
+            ),
+            "restrict_external_sharing": self._as_list(
+                self._first_present(
+                    tenant_settings,
+                    "RestrictExternalSharing",
+                    "restrictExternalSharing",
+                )
+            ),
+            "external_user_expiration_required": self._first_present(
+                tenant_settings,
+                "ExternalUserExpirationRequired",
+                "externalUserExpirationRequired",
+            ),
+            "external_user_expire_in_days": self._first_present(
+                tenant_settings,
+                "ExternalUserExpireInDays",
+                "externalUserExpireInDays",
+            ),
+            "email_attestation_required": self._first_present(
+                tenant_settings,
+                "EmailAttestationRequired",
+                "emailAttestationRequired",
+            ),
+            "email_attestation_reauth_days": self._first_present(
+                tenant_settings,
+                "EmailAttestationReAuthDays",
+                "emailAttestationReAuthDays",
+            ),
+            "disallow_infected_file_download": self._first_present(
+                tenant_settings,
+                "DisallowInfectedFileDownload",
+                "disallowInfectedFileDownload",
+            ),
+            "core_default_share_link_scope": self._first_present(
+                tenant_settings,
+                "CoreDefaultShareLinkScope",
+                "coreDefaultShareLinkScope",
+            ),
+            "core_default_share_link_role": self._first_present(
+                tenant_settings,
+                "CoreDefaultShareLinkRole",
+                "coreDefaultShareLinkRole",
+            ),
+            "onedrive_default_share_link_scope": self._first_present(
+                tenant_settings,
+                "OneDriveDefaultShareLinkScope",
+                "oneDriveDefaultShareLinkScope",
+            ),
+            "onedrive_default_share_link_role": self._first_present(
+                tenant_settings,
+                "OneDriveDefaultShareLinkRole",
+                "oneDriveDefaultShareLinkRole",
+            ),
+        }

--- a/engine/collectors/sharepoint_client.py
+++ b/engine/collectors/sharepoint_client.py
@@ -1,103 +1,155 @@
-"""SharePoint REST API client.
+"""Microsoft Graph client for SharePoint and OneDrive tenant controls.
 
-This module provides connectivity to SharePoint Online using REST API instead
-of PowerShell because SharePoint Online PowerShell does not support client
-secret authentication for app-only scenarios.
-
-Authentication: Client secret via MSAL -> access token for SharePoint resource
-
-CAVEAT: Access token authentication has not been fully tested.
-    It should work, but needs verification during implementation. Certificate-based
-    authentication may be required instead of client secret authentication.
-
-NOTE: If certificate authentication is adopted in the future, consider replacing
-these REST API calls with PowerShell cmdlets (Get-SPOTenant, Get-SPOSite, etc.)
-for consistency with other collectors.
-
-SharePoint REST API Reference:
-- Tenant Admin API: https://{tenant}-admin.sharepoint.com/_api/
-- Site API: https://{site-url}/_api/
+This module uses Microsoft Graph application permissions with client-secret
+authentication only. It replaces the older SharePoint REST/admin API flow so
+SharePoint collectors can run without a tenant-specific SharePoint token.
 """
 
 from typing import Any
+from urllib.parse import urlparse
 
-import httpx
-from msal import ConfidentialClientApplication
+from collectors.graph_client import GraphClient
 
 
-class SharePointClient:
-    """Client for SharePoint Online REST API using client secret auth."""
-
-    def __init__(self, tenant_id: str, client_id: str, client_secret: str, tenant_name: str):
-        """Initialize SharePoint client.
-
-        Args:
-            tenant_id: Azure AD tenant ID
-            client_id: Application (client) ID
-            client_secret: Client secret for authentication
-            tenant_name: SharePoint tenant name (e.g., 'contoso' for contoso.sharepoint.com)
-        """
-        self.tenant_id = tenant_id
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.tenant_name = tenant_name
-        self.admin_url = f"https://{tenant_name}-admin.sharepoint.com"
-        self._access_token: str | None = None
-
-        self._msal_app = ConfidentialClientApplication(
-            client_id=client_id,
-            client_credential=client_secret,
-            authority=f"https://login.microsoftonline.com/{tenant_id}",
-        )
-
-    async def _get_access_token(self) -> str:
-        """Get access token for SharePoint.
-
-        Returns:
-            Access token string.
-
-        Raises:
-            Exception: If token acquisition fails.
-        """
-        if self._access_token:
-            return self._access_token
-
-        result = self._msal_app.acquire_token_for_client(
-            scopes=[f"{self.admin_url}/.default"]
-        )
-        if "access_token" not in result:
-            error = result.get("error_description", result.get("error", "Unknown"))
-            raise Exception(f"Failed to acquire SharePoint token: {error}")
-
-        self._access_token = result["access_token"]
-        return self._access_token
+class SharePointClient(GraphClient):
+    """Graph-backed client for SharePoint Online tenant data."""
 
     async def get_tenant_settings(self) -> dict[str, Any]:
-        """Get SPO tenant settings via REST API.
+        """Get SharePoint/OneDrive tenant settings from Microsoft Graph."""
+        response = await self.get("/admin/sharepoint/settings")
+        if not isinstance(response, dict):
+            raise TypeError("Unexpected Graph sharePointSettings response shape")
+        return response
 
-        Returns:
-            Dict containing tenant configuration properties.
-        """
-        # TODO: Implement REST API call
-        raise NotImplementedError("SharePoint client not yet implemented")
+    async def search_sites(
+        self,
+        *,
+        include_personal_sites: bool = True,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Enumerate SharePoint sites using Microsoft Graph."""
+        response = await self.get("/sites/getAllSites")
+
+        sites: list[dict[str, Any]] = []
+        next_link = response.get("@odata.nextLink")
+        page_items = response.get("value", [])
+
+        while True:
+            for item in page_items:
+                if not isinstance(item, dict):
+                    continue
+
+                web_url = item.get("webUrl")
+                if not isinstance(web_url, str) or not web_url:
+                    continue
+
+                is_personal_site = "-my.sharepoint.com/" in web_url.lower()
+                if not include_personal_sites and is_personal_site:
+                    continue
+
+                sites.append(
+                    {
+                        "title": item.get("displayName") or item.get("name"),
+                        "url": web_url,
+                        "site_id": item.get("id"),
+                        "web_template": item.get("webTemplate"),
+                        "content_class": "STS_Web" if is_personal_site else "STS_Site",
+                    }
+                )
+
+                if len(sites) >= limit:
+                    return sites
+
+            if not next_link:
+                break
+
+            next_page = await self._request("GET", next_link.replace(self.GRAPH_BASE_URL, ""))
+            if not isinstance(next_page, dict):
+                raise TypeError("Unexpected Graph sites pagination response shape")
+            page_items = next_page.get("value", [])
+            next_link = next_page.get("@odata.nextLink")
+
+        return sites
 
     async def get_site_properties(self, site_url: str) -> dict[str, Any]:
-        """Get site properties via REST API.
+        """Get basic site properties for a SharePoint site via Microsoft Graph."""
+        parsed = urlparse(site_url)
+        hostname = parsed.netloc
+        relative_path = parsed.path.rstrip("/")
 
-        Args:
-            site_url: The SharePoint site URL
+        if not hostname:
+            raise ValueError(f"Invalid SharePoint site URL: {site_url}")
 
-        Returns:
-            Dict containing site properties.
-        """
-        # TODO: Implement REST API call
-        raise NotImplementedError("SharePoint client not yet implemented")
+        endpoint = f"/sites/{hostname}:{relative_path}" if relative_path else f"/sites/{hostname}"
+        site_info = await self.get(
+            endpoint,
+            params={"$select": "id,displayName,name,webUrl,siteCollection,createdDateTime"},
+        )
+
+        if not isinstance(site_info, dict):
+            raise TypeError("Unexpected Graph site response shape")
+
+        return {
+            "site": {
+                "Id": site_info.get("id"),
+                "Url": site_info.get("webUrl"),
+            },
+            "web": {
+                "Id": site_info.get("id"),
+                "Title": site_info.get("displayName") or site_info.get("name"),
+                "Url": site_info.get("webUrl"),
+                "WebTemplate": site_info.get("webTemplate"),
+            },
+        }
 
     async def get_sync_client_restriction(self) -> dict[str, Any]:
-        """Get OneDrive sync client restriction settings.
+        """Get OneDrive sync client restriction settings from tenant settings."""
+        tenant_settings = await self.get_tenant_settings()
 
-        Returns:
-            Dict containing sync client restriction settings.
-        """
-        # TODO: Implement REST API call
-        raise NotImplementedError("SharePoint client not yet implemented")
+        allowed_domain_guids = tenant_settings.get("allowedDomainGuidsForSyncApp")
+        if allowed_domain_guids is None:
+            allowed_domain_guids = tenant_settings.get("AllowedDomainList")
+        if allowed_domain_guids is None:
+            allowed_domain_guids = tenant_settings.get("allowedDomainList")
+
+        excluded_file_extensions = tenant_settings.get("excludedFileExtensionsForSyncApp")
+        if excluded_file_extensions is None:
+            excluded_file_extensions = tenant_settings.get("ExcludedFileExtensions")
+        if excluded_file_extensions is None:
+            excluded_file_extensions = tenant_settings.get("excludedFileExtensions")
+
+        return {
+            "TenantRestrictionEnabled": tenant_settings.get(
+                "isUnmanagedSyncAppForTenantRestricted",
+                tenant_settings.get(
+                    "TenantRestrictionEnabled",
+                    tenant_settings.get("tenantRestrictionEnabled"),
+                ),
+            ),
+            "AllowedDomainList": self._normalize_list(allowed_domain_guids),
+            "BlockMacSync": (
+                tenant_settings.get("BlockMacSync", tenant_settings.get("blockMacSync"))
+                if "isMacSyncAppEnabled" not in tenant_settings
+                else not bool(tenant_settings["isMacSyncAppEnabled"])
+            ),
+            "GrooveBlockOption": tenant_settings.get(
+                "GrooveBlockOption",
+                tenant_settings.get("grooveBlockOption"),
+            ),
+            "ExcludedFileExtensions": self._normalize_list(excluded_file_extensions),
+        }
+
+    @staticmethod
+    def _normalize_list(value: Any) -> list[Any]:
+        """Normalize Graph list-like payloads to plain Python lists."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, str):
+            if not value.strip():
+                return []
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return [value]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.1_modern_authentication_sharepoint_applications_required.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.1_modern_authentication_sharepoint_applications_required.rego
@@ -1,0 +1,57 @@
+# METADATA
+# title: Ensure modern authentication for SharePoint applications is required
+# description: |
+#   Modern authentication in SharePoint Online helps enforce stronger authentication
+#   controls and reduces exposure to legacy protocols that do not support modern
+#   security protections such as MFA and Conditional Access.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-7.2.1
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: high
+#   service: SharePoint
+#   requires_permissions:
+#   - SharePointTenantSettings.Read.All
+
+package cis.microsoft_365_foundations.v6_0_0.control_7_2_1
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := output if {
+    legacy_auth_enabled := object.get(input, "legacy_auth_protocols_enabled", null)
+
+    output := {
+        "compliant": legacy_auth_enabled == false,
+        "message": generate_message(legacy_auth_enabled),
+        "affected_resources": generate_affected_resources(legacy_auth_enabled),
+        "details": {
+            "legacy_auth_protocols_enabled": legacy_auth_enabled
+        }
+    }
+}
+
+generate_message(legacy_auth_enabled) := "Legacy authentication protocols are disabled at the SharePoint tenant level" if {
+    legacy_auth_enabled == false
+}
+
+generate_message(legacy_auth_enabled) := "Legacy authentication protocols are enabled at the SharePoint tenant level" if {
+    legacy_auth_enabled == true
+}
+
+generate_message(legacy_auth_enabled) := "Unable to determine whether legacy authentication protocols are enabled at the SharePoint tenant level" if {
+    legacy_auth_enabled == null
+}
+
+generate_affected_resources(false) := []
+
+generate_affected_resources(true) := [
+    "Legacy authentication protocols are enabled"
+]
+
+generate_affected_resources(null) := [
+    "Legacy authentication protocol status unknown"
+]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
@@ -1,0 +1,73 @@
+# METADATA
+# title: Ensure external content sharing is restricted
+# description: |
+#   The external sharing settings govern sharing for the organization overall. 
+#   Each site has its own sharing setting that can be set independently, 
+#   though it must be at the same or more restrictive setting as the organization.
+#   The recommended state is New and existing guests or less permissive.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-7.2.3
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   service: SharePoint
+#   requires_permissions:
+#   - SharePointTenantSettings.Read.All
+
+package cis.microsoft_365_foundations.v6_0_0.control_7_2_3
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := {
+    "compliant": compliant,
+    "message": message,
+    "affected_resources": affected_resources,
+    "details": {
+        "sharing_capability": sharing_capability,
+    },
+} if {
+    sharing_capability := object.get(input, "sharing_capability", null)
+    normalized := lower(sprintf("%v", [sharing_capability]))
+    compliant := is_restricted(sharing_capability, normalized)
+    message := generate_message(sharing_capability, normalized, compliant)
+    affected_resources := generate_affected_resources(sharing_capability, compliant)
+}
+
+is_restricted(sharing_capability, normalized) if {
+    sharing_capability != null
+    not contains(normalized, "anyone")
+}
+
+generate_message(sharing_capability, normalized, compliant) := "SharePoint external content sharing is disabled" if {
+    sharing_capability != null
+    compliant
+    normalized == "disabled"
+}
+
+generate_message(sharing_capability, normalized, compliant) := "SharePoint external content sharing is restricted" if {
+    sharing_capability != null
+    compliant
+    normalized != "disabled"
+}
+
+generate_message(sharing_capability, _, compliant) := "SharePoint external content sharing allows Anyone links" if {
+    sharing_capability != null
+    not compliant
+}
+
+generate_message(null, _, _) := "Unable to determine the SharePoint external sharing capability"
+
+generate_affected_resources(sharing_capability, compliant) := [] if {
+    sharing_capability != null
+    compliant
+}
+
+generate_affected_resources(sharing_capability, compliant) := [sprintf("sharing_capability=%v", [sharing_capability])] if {
+    sharing_capability != null
+    not compliant
+}
+
+generate_affected_resources(null, _) := ["SharePoint external sharing capability unknown"]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
@@ -30,15 +30,26 @@ result := {
     },
 } if {
     sharing_capability := object.get(input, "sharing_capability", null)
-    normalized := lower(sprintf("%v", [sharing_capability]))
+    normalized := lower(trim(sprintf("%v", [sharing_capability]), " \t\r\n"))
     compliant := is_restricted(sharing_capability, normalized)
     message := generate_message(sharing_capability, normalized, compliant)
     affected_resources := generate_affected_resources(sharing_capability, compliant)
 }
 
+restricted_sharing_values := {
+    "disabled",
+    "existingexternalusersharingonly",
+    "externalusersharingonly",
+    "existing external users sharing only",
+    "external users sharing only",
+    "existing guests",
+    "existing guests only",
+    "new and existing guests",
+}
+
 is_restricted(sharing_capability, normalized) if {
     sharing_capability != null
-    not contains(normalized, "anyone")
+    restricted_sharing_values[normalized]
 }
 
 generate_message(sharing_capability, normalized, compliant) := "SharePoint external content sharing is disabled" if {

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.3_external_content_sharing_restricted.rego
@@ -4,7 +4,8 @@
 #   The external sharing settings govern sharing for the organization overall. 
 #   Each site has its own sharing setting that can be set independently, 
 #   though it must be at the same or more restrictive setting as the organization.
-#   The recommended state is New and existing guests or less permissive.
+#   The recommended state is ExternalUserSharingOnly, ExistingExternalUserSharingOnly,
+#   or Disabled.
 # related_resources:
 # - ref: https://www.cisecurity.org/benchmark/microsoft_365
 #   description: CIS Microsoft 365 Foundations Benchmark
@@ -31,7 +32,7 @@ result := {
 } if {
     sharing_capability := object.get(input, "sharing_capability", null)
     normalized := lower(trim(sprintf("%v", [sharing_capability]), " \t\r\n"))
-    compliant := is_restricted(sharing_capability, normalized)
+    compliant := restricted_value(sharing_capability, normalized)
     message := generate_message(sharing_capability, normalized, compliant)
     affected_resources := generate_affected_resources(sharing_capability, compliant)
 }
@@ -44,13 +45,16 @@ restricted_sharing_values := {
     "external users sharing only",
     "existing guests",
     "existing guests only",
-    "new and existing guests",
 }
 
 is_restricted(sharing_capability, normalized) if {
     sharing_capability != null
     restricted_sharing_values[normalized]
 }
+
+restricted_value(sharing_capability, normalized) := true if {
+    is_restricted(sharing_capability, normalized)
+} else := false
 
 generate_message(sharing_capability, normalized, compliant) := "SharePoint external content sharing is disabled" if {
     sharing_capability != null
@@ -64,7 +68,7 @@ generate_message(sharing_capability, normalized, compliant) := "SharePoint exter
     normalized != "disabled"
 }
 
-generate_message(sharing_capability, _, compliant) := "SharePoint external content sharing allows Anyone links" if {
+generate_message(sharing_capability, _, compliant) := "SharePoint external content sharing is not restricted to the CIS-approved values" if {
     sharing_capability != null
     not compliant
 }

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.4_onedrive_content_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.4_onedrive_content_sharing_restricted.rego
@@ -1,0 +1,77 @@
+# METADATA
+# title: Ensure OneDrive content sharing is restricted
+# description: |
+#   This setting governs the global permissiveness of OneDrive content sharing in the organization.
+#   OneDrive content sharing can be restricted independent of SharePoint but can never be more 
+#   permissive than the level established with SharePoint.
+#   The recommended state is Only people in your organization.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-7.2.4
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   service: SharePoint
+#   requires_permissions:
+#   - SharePointTenantSettings.Read.All
+
+package cis.microsoft_365_foundations.v6_0_0.control_7_2_4
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := {
+    "compliant": compliant,
+    "message": message,
+    "affected_resources": affected_resources,
+    "details": {
+        "onedrive_sharing_capability": sharing_capability,
+    },
+} if {
+    sharing_capability := object.get(input, "onedrive_sharing_capability", null)
+    normalized := lower(sprintf("%v", [sharing_capability]))
+    compliant := restricted_value(sharing_capability, normalized)
+    message := generate_message(sharing_capability, normalized, compliant)
+    affected_resources := generate_affected_resources(sharing_capability, compliant)
+}
+
+is_restricted(sharing_capability, normalized) if {
+    sharing_capability != null
+    not contains(normalized, "anyone")
+}
+
+restricted_value(sharing_capability, normalized) := true if {
+    is_restricted(sharing_capability, normalized)
+} else := false
+
+generate_message(sharing_capability, normalized, compliant) := "OneDrive content sharing is disabled" if {
+    sharing_capability != null
+    compliant
+    normalized == "disabled"
+}
+
+generate_message(sharing_capability, normalized, compliant) := "OneDrive content sharing is restricted" if {
+    sharing_capability != null
+    compliant
+    normalized != "disabled"
+}
+
+generate_message(sharing_capability, _, compliant) := "OneDrive content sharing allows Anyone links" if {
+    sharing_capability != null
+    not compliant
+}
+
+generate_message(null, _, _) := "Unable to determine the OneDrive sharing capability"
+
+generate_affected_resources(sharing_capability, compliant) := [] if {
+    sharing_capability != null
+    compliant
+}
+
+generate_affected_resources(sharing_capability, compliant) := [sprintf("onedrive_sharing_capability=%v", [sharing_capability])] if {
+    sharing_capability != null
+    not compliant
+}
+
+generate_affected_resources(null, _) := ["OneDrive sharing capability unknown"]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.4_onedrive_content_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.4_onedrive_content_sharing_restricted.rego
@@ -2,7 +2,7 @@
 # title: Ensure OneDrive content sharing is restricted
 # description: |
 #   This setting governs the global permissiveness of OneDrive content sharing in the organization.
-#   OneDrive content sharing can be restricted independent of SharePoint but can never be more 
+#   OneDrive content sharing can be restricted independent of SharePoint but can never be more
 #   permissive than the level established with SharePoint.
 #   The recommended state is Only people in your organization.
 # related_resources:
@@ -30,34 +30,33 @@ result := {
     },
 } if {
     sharing_capability := object.get(input, "onedrive_sharing_capability", null)
-    normalized := lower(sprintf("%v", [sharing_capability]))
-    compliant := restricted_value(sharing_capability, normalized)
+    normalized := lower(trim(sprintf("%v", [sharing_capability]), " \t\r\n"))
+    compliant := organization_only_value(sharing_capability, normalized)
     message := generate_message(sharing_capability, normalized, compliant)
     affected_resources := generate_affected_resources(sharing_capability, compliant)
 }
 
-is_restricted(sharing_capability, normalized) if {
-    sharing_capability != null
-    not contains(normalized, "anyone")
+organization_only_values := {
+    "disabled",
+    "only people in your organization",
+    "onlypeopleinyourorganization",
 }
 
-restricted_value(sharing_capability, normalized) := true if {
-    is_restricted(sharing_capability, normalized)
+is_organization_only(sharing_capability, normalized) if {
+    sharing_capability != null
+    organization_only_values[normalized]
+}
+
+organization_only_value(sharing_capability, normalized) := true if {
+    is_organization_only(sharing_capability, normalized)
 } else := false
 
-generate_message(sharing_capability, normalized, compliant) := "OneDrive content sharing is disabled" if {
+generate_message(sharing_capability, _, compliant) := "OneDrive content sharing is limited to people in your organization" if {
     sharing_capability != null
     compliant
-    normalized == "disabled"
 }
 
-generate_message(sharing_capability, normalized, compliant) := "OneDrive content sharing is restricted" if {
-    sharing_capability != null
-    compliant
-    normalized != "disabled"
-}
-
-generate_message(sharing_capability, _, compliant) := "OneDrive content sharing allows Anyone links" if {
+generate_message(sharing_capability, _, compliant) := "OneDrive content sharing allows external sharing" if {
     sharing_capability != null
     not compliant
 }

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.5_guest_users_cannot_share_items_not_owned.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/7.2.5_guest_users_cannot_share_items_not_owned.rego
@@ -1,0 +1,40 @@
+# METADATA
+# title: Ensure that SharePoint guest users cannot share items they don't own
+# description: |
+#   SharePoint gives users the ability to share files, folders, and site collections. 
+#   Internal users can share with external collaborators, and with the right permissions 
+#   could share to other external parties.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-7.2.5
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   service: SharePoint
+#   requires_permissions:
+#   - SharePointTenantSettings.Read.All
+
+package cis.microsoft_365_foundations.v6_0_0.control_7_2_5
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := {
+    "compliant": setting == true,
+    "message": generate_message(setting),
+    "affected_resources": generate_affected_resources(setting),
+    "details": {
+        "prevent_external_users_from_resharing": setting,
+    },
+} if {
+    setting := object.get(input, "prevent_external_users_from_resharing", null)
+}
+
+generate_message(true) := "Guest users cannot re-share content they do not own"
+generate_message(false) := "Guest users can re-share content they do not own"
+generate_message(null) := "Unable to determine whether guest users can re-share content they do not own"
+
+generate_affected_resources(true) := []
+generate_affected_resources(false) := ["PreventExternalUsersFromResharing is disabled"]
+generate_affected_resources(null) := ["PreventExternalUsersFromResharing status unknown"]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -1486,11 +1486,11 @@
       "level": "L1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "sharepoint.spo_tenant",
-      "policy_file": null,
-      "requires_permissions": ["SharePoint.Admin"],
-      "notes": "Collector raises NotImplementedError"
+      "policy_file": "7.2.1_modern_authentication_sharepoint_applications_required.rego",
+      "requires_permissions": ["SharePointTenantSettings.Read.All"],
+      "notes": null
     },
     {
       "control_id": "7.2.2",
@@ -1499,13 +1499,13 @@
       "severity": "medium",
       "service": "SharePoint",
       "level": "L1",
-      "is_manual": false,
-      "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
-      "data_collector_id": "sharepoint.spo_tenant",
+      "is_manual": true,
+      "benchmark_audit_type": "Manual",
+      "automation_status": "manual",
+      "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": ["SharePoint.Admin"],
-      "notes": "Collector raises NotImplementedError"
+      "requires_permissions": null,
+      "notes": "Not supported through Microsoft Graph sharePointSettings."
     },
     {
       "control_id": "7.2.3",
@@ -1516,9 +1516,9 @@
       "level": "L1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "sharepoint.spo_tenant",
-      "policy_file": null,
+      "policy_file": "7.2.3_external_content_sharing_restricted.rego",
       "requires_permissions": ["SharePoint.Admin"],
       "notes": "Collector raises NotImplementedError"
     },
@@ -1531,11 +1531,11 @@
       "level": "L2",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "sharepoint.spo_tenant",
-      "policy_file": null,
-      "requires_permissions": ["SharePoint.Admin"],
-      "notes": "Collector raises NotImplementedError"
+      "policy_file": "7.2.4_onedrive_content_sharing_restricted.rego",
+      "requires_permissions": ["SharePointTenantSettings.Read.All"],
+      "notes": null
     },
     {
       "control_id": "7.2.5",
@@ -1546,11 +1546,11 @@
       "level": "L2",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "sharepoint.spo_tenant",
-      "policy_file": null,
-      "requires_permissions": ["SharePoint.Admin"],
-      "notes": "Collector raises NotImplementedError"
+      "policy_file": "7.2.5_guest_users_cannot_share_items_not_owned.rego",
+      "requires_permissions": ["SharePointTenantSettings.Read.All"],
+      "notes": null
     },
     {
       "control_id": "7.2.6",

--- a/engine/scripts/test_collector.py
+++ b/engine/scripts/test_collector.py
@@ -30,6 +30,7 @@ from collectors.registry import DATA_COLLECTORS, get_collector
 from collectors.graph_client import GraphClient
 from collectors.powershell_base import BasePowerShellCollector
 from collectors.powershell_client import PowerShellClient, PowerShellExecutionError
+from collectors.sharepoint_client import SharePointClient
 
 
 def list_collectors() -> None:
@@ -177,6 +178,7 @@ async def test_all_collectors(
     tenant_id, client_id, client_secret = get_credentials()
     graph_client = GraphClient(tenant_id, client_id, client_secret)
     ps_client = None  # Lazy init PowerShell client
+    sharepoint_client = None
 
     results = []
     for collector_id in sorted(DATA_COLLECTORS.keys()):
@@ -188,6 +190,14 @@ async def test_all_collectors(
             if ps_client is None:
                 ps_client = PowerShellClient(tenant_id, client_id, client_secret, service_url=service_url)
             client = ps_client
+        elif collector_id.startswith("sharepoint."):
+            if sharepoint_client is None:
+                sharepoint_client = SharePointClient(
+                    tenant_id=tenant_id,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+            client = sharepoint_client
         else:
             client = graph_client
 

--- a/engine/worker/tasks.py
+++ b/engine/worker/tasks.py
@@ -48,6 +48,33 @@ def get_control_metadata(metadata: dict, control_id: str) -> dict | None:
     return None
 
 
+def build_result_message(result: dict, control: dict, default_compliant: bool) -> str:
+    """Return a user-facing message for a control evaluation result.
+
+    Prefer the policy-provided message, but fall back to a control-aware message
+    so scan results do not degrade to a generic compliant/non-compliant label.
+    """
+    message = result.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+
+    title = control.get("title") or f"Control {control.get('control_id', 'unknown')}"
+    affected_resources = result.get("affected_resources")
+    if isinstance(affected_resources, list):
+        first_affected = next(
+            (item.strip() for item in affected_resources if isinstance(item, str) and item.strip()),
+            None,
+        )
+        if first_affected:
+            if default_compliant:
+                return f"{title} is compliant."
+            return f"{title} is non-compliant: {first_affected}"
+
+    if default_compliant:
+        return f"{title} is compliant."
+    return f"{title} is non-compliant."
+
+
 @celery_app.task(name="worker.tasks.run_scan")
 def run_scan(scan_id: int) -> dict:
     """Orchestrator task: Dispatches control evaluation tasks.
@@ -271,7 +298,7 @@ def evaluate_control(
                     session,
                     result_id=result_id,
                     status="passed",
-                    message=result.get("message", "Control is compliant"),
+                    message=build_result_message(result, control, default_compliant=True),
                     evidence=result.get("details"),
                 )
                 increment_scan_progress(session, scan_id, passed=True)
@@ -281,7 +308,7 @@ def evaluate_control(
                     session,
                     result_id=result_id,
                     status="failed",
-                    message=result.get("message", "Control is non-compliant"),
+                    message=build_result_message(result, control, default_compliant=False),
                     evidence=result.get("details"),
                 )
                 increment_scan_progress(session, scan_id, passed=False)
@@ -348,6 +375,7 @@ async def _evaluate_control_async(
     from collectors.registry import get_collector
     from collectors.graph_client import GraphClient
     from collectors.powershell_client import PowerShellClient
+    from collectors.sharepoint_client import SharePointClient
     from opa_client import opa_client
 
     # Get collector
@@ -365,6 +393,12 @@ async def _evaluate_control_async(
             client_id=credentials["client_id"],
             client_secret=credentials["client_secret"],
             service_url=settings.POWERSHELL_SERVICE_URL,
+        )
+    elif collector_id.startswith("sharepoint."):
+        client = SharePointClient(
+            tenant_id=credentials["tenant_id"],
+            client_id=credentials["client_id"],
+            client_secret=credentials["client_secret"],
         )
     else:
         # Entra and other collectors use Graph API


### PR DESCRIPTION
**Summary of the Changes**
The pull request introduces new SharePoint-specific collectors required for compliance scanning of Section 7 in Microsoft 365. Additionally, the connection method uses Microsoft Graph, with the necessary SharePoint API permissions enabled in Entra ID (Azure AD).

**Components**

- `/engine (collectors / policies)`

**Testing Done**

- `Tested run locally`

**Rollback**

- `Revert the commit changes`

**Screenshots**

<img width="1479" height="563" alt="image" src="https://github.com/user-attachments/assets/1ae43b89-04a8-470b-af66-ead1ba779c62" />
