### PR TITLE
feat(scans): add GET /scans/{id}/summary endpoint

### DIFF
--- a/backend-api/app/api/v1/scans.py
+++ b/backend-api/app/api/v1/scans.py
@@ -1,0 +1,280 @@
+"""Scan API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from collections import defaultdict
+from typing import Literal
+
+from app.core.auth import get_current_user
+from app.db.session import get_async_session
+from app.models.compliance import Scan
+from app.models.m365_connection import M365Connection
+from app.models.scan_result import ScanResult
+from app.models.user import User
+from app.schemas.scan import (
+    ScanCreate,
+    ScanCreatedResponse,
+    ControlCategoryBreakdown,
+    ScanListItem,
+    ScanRead,
+    ScanResultRead,
+    ScanSummary,
+)
+from app.services.benchmark_reader import get_file_reader
+from app.services.celery_client import queue_scan
+
+router = APIRouter(prefix="/scans", tags=["Scans"])
+
+
+@router.post("/", response_model=ScanCreatedResponse, status_code=status.HTTP_201_CREATED)
+async def create_scan(
+    scan_data: ScanCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> ScanCreatedResponse:
+    """Create a new compliance scan.
+
+    Creates a scan record with all ScanResult records and queues a Celery task.
+    The scan runs asynchronously - poll GET /scans/{id} for status.
+    """
+    # Verify the connection exists and belongs to the user
+    result = await db.execute(
+        select(M365Connection).where(
+            M365Connection.id == scan_data.m365_connection_id,
+            M365Connection.user_id == current_user.id,
+            M365Connection.is_active == True,
+        )
+    )
+    connection = result.scalar_one_or_none()
+    if not connection:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"M365 connection {scan_data.m365_connection_id} not found or inactive",
+        )
+
+    # Load benchmark metadata to get all controls
+    file_reader = get_file_reader()
+    try:
+        all_controls = file_reader.list_controls(
+            scan_data.framework, scan_data.benchmark, scan_data.version
+        )
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Benchmark {scan_data.framework}/{scan_data.benchmark}/{scan_data.version} not found",
+        )
+
+    # Validate platform matches (benchmark must be for m365)
+    metadata = file_reader.get_benchmark_metadata(
+        scan_data.framework, scan_data.benchmark, scan_data.version
+    )
+    if metadata.get("platform", "").lower() != "m365":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Benchmark platform '{metadata.get('platform')}' does not match M365 connection",
+        )
+
+    # Create scan record
+    scan = Scan(
+        user_id=current_user.id,
+        m365_connection_id=scan_data.m365_connection_id,
+        framework=scan_data.framework,
+        benchmark=scan_data.benchmark,
+        version=scan_data.version,
+        status="pending",
+        total_controls=len(all_controls),
+    )
+    db.add(scan)
+    await db.flush()  # Get scan.id
+
+    # Create ScanResult records for ALL controls
+    selected_ids = set(scan_data.control_ids) if scan_data.control_ids else None
+    skipped = 0
+    for control in all_controls:
+        is_selected = selected_ids is None or control["control_id"] in selected_ids
+        result_status = "pending" if is_selected else "skipped"
+        if result_status == "skipped":
+            skipped += 1
+        scan_result = ScanResult(
+            scan_id=scan.id,
+            control_id=control["control_id"],
+            status=result_status,
+        )
+        db.add(scan_result)
+
+    scan.skipped_count = skipped
+    await db.commit()
+    await db.refresh(scan)
+
+    # Queue Celery task
+    task = queue_scan(scan.id)
+
+    return ScanCreatedResponse(
+        id=scan.id,
+        status="pending",
+        message=f"Scan queued successfully. Task ID: {task.id}",
+    )
+
+
+@router.get("/", response_model=list[ScanListItem])
+async def list_scans(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+    limit: int = 50,
+    offset: int = 0,
+) -> list[Scan]:
+    """List scans for the current user."""
+    result = await db.execute(
+        select(Scan)
+        .options(selectinload(Scan.m365_connection))
+        .where(Scan.user_id == current_user.id)
+        .order_by(Scan.started_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return list(result.scalars().all())
+
+
+@router.get("/{scan_id}", response_model=ScanRead)
+async def get_scan(
+    scan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> Scan:
+    """Get scan details by ID including results."""
+    result = await db.execute(
+        select(Scan)
+        .options(selectinload(Scan.results), selectinload(Scan.m365_connection))
+        .where(Scan.id == scan_id, Scan.user_id == current_user.id)
+    )
+    scan = result.scalar_one_or_none()
+    if not scan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Scan {scan_id} not found",
+        )
+    return scan
+
+
+@router.get("/{scan_id}/summary", response_model=ScanSummary)
+async def get_scan_summary(
+    scan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> ScanSummary:
+    """Get a lightweight compliance summary for a scan.
+
+    Returns score and counts immediately, plus a breakdown
+    by control category prefix (e.g. 1.x, 2.x for CIS,
+    AC, AU for NIST). Works across all frameworks.
+    """
+    result = await db.execute(
+        select(Scan).where(
+            Scan.id == scan_id,
+            Scan.user_id == current_user.id,
+        )
+    )
+    scan = result.scalar_one_or_none()
+    if not scan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Scan {scan_id} not found",
+        )
+
+    results = await db.execute(
+        select(ScanResult.control_id, ScanResult.status).where(
+            ScanResult.scan_id == scan_id
+        )
+    )
+    rows = results.all()
+
+    buckets: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "error": 0}
+    )
+    for control_id, status_ in rows:
+        prefix = (
+            control_id.split(".")[0]
+            if "." in control_id
+            else control_id.split("-")[0]
+        )
+        buckets[prefix]["total"] += 1
+        if status_ in buckets[prefix]:
+            buckets[prefix][status_] += 1
+
+    categories = [
+        ControlCategoryBreakdown(category=cat, **counts)
+        for cat, counts in sorted(buckets.items())
+    ]
+
+    return ScanSummary(
+        id=scan.id,
+        status=scan.status,
+        framework=scan.framework,
+        benchmark=scan.benchmark,
+        version=scan.version,
+        started_at=scan.started_at,
+        finished_at=scan.finished_at,
+        compliance_score=scan.compliance_score,
+        total_controls=scan.total_controls,
+        passed_count=scan.passed_count,
+        failed_count=scan.failed_count,
+        skipped_count=scan.skipped_count,
+        error_count=scan.error_count,
+        categories=categories,
+    )
+
+@router.get("/{scan_id}/results", response_model=list[ScanResultRead])
+async def get_scan_results(
+    scan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+    status_filter: str | None = None,
+) -> list[ScanResult]:
+    """Get results for a scan.
+
+    Optionally filter by status (pending, passed, failed, error, skipped).
+    """
+    # Verify scan exists and user has access
+    scan_result = await db.execute(
+        select(Scan).where(Scan.id == scan_id, Scan.user_id == current_user.id)
+    )
+    scan = scan_result.scalar_one_or_none()
+    if not scan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Scan {scan_id} not found",
+        )
+
+    # Build query
+    query = select(ScanResult).where(ScanResult.scan_id == scan_id)
+    if status_filter:
+        query = query.where(ScanResult.status == status_filter)
+    query = query.order_by(ScanResult.control_id)
+
+    results = await db.execute(query)
+    return list(results.scalars().all())
+
+
+@router.delete("/{scan_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_scan(
+    scan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> None:
+    """Delete a scan (hard delete) and its results."""
+    result = await db.execute(
+        select(Scan).where(Scan.id == scan_id, Scan.user_id == current_user.id)
+    )
+    scan = result.scalar_one_or_none()
+    if not scan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Scan {scan_id} not found",
+        )
+
+    # Delete dependent results first (FK is not ON DELETE CASCADE).
+    await db.execute(delete(ScanResult).where(ScanResult.scan_id == scan_id))
+    await db.delete(scan)
+    await db.commit()

--- a/backend-api/app/schemas/scan.py
+++ b/backend-api/app/schemas/scan.py
@@ -1,0 +1,103 @@
+"""Pydantic schemas for compliance scans."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScanCreate(BaseModel):
+    """Schema for creating a new scan."""
+
+    m365_connection_id: int = Field(
+        ..., description="ID of the M365 connection to scan"
+    )
+    framework: str = Field(
+        ..., min_length=1, max_length=50, description="Framework (e.g., 'cis')"
+    )
+    benchmark: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Benchmark slug (e.g., 'microsoft-365-foundations')",
+    )
+    version: str = Field(
+        ..., min_length=1, max_length=20, description="Version (e.g., 'v3.1.0')"
+    )
+    control_ids: list[str] | None = Field(
+        None, description="Specific control IDs to scan (null = all)"
+    )
+
+
+class ScanResultRead(BaseModel):
+    """Schema for reading scan result details."""
+
+    id: int
+    scan_id: int
+    control_id: str
+    status: str  # pending, passed, failed, error, skipped
+    message: str | None
+    evidence: dict | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ScanRead(BaseModel):
+    """Schema for reading scan details."""
+
+    id: int
+    user_id: int
+    m365_connection_id: int | None
+    connection_name: str | None = None
+    azure_connection_id: int | None
+    gcp_connection_id: int | None
+    aws_connection_id: int | None
+    framework: str
+    benchmark: str
+    version: str
+    status: str
+    started_at: datetime
+    finished_at: datetime | None
+    compliance_score: Decimal | None
+    total_controls: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    error_count: int
+    notes: str | None
+    results: list[ScanResultRead] | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ScanListItem(BaseModel):
+    """Schema for scan list items (abbreviated)."""
+
+    id: int
+    user_id: int
+    m365_connection_id: int | None
+    connection_name: str | None = None
+    framework: str
+    benchmark: str
+    version: str
+    status: str
+    started_at: datetime
+    finished_at: datetime | None
+    compliance_score: Decimal | None
+    total_controls: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    error_count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ScanCreatedResponse(BaseModel):
+    """Response schema for scan creation."""
+
+    id: int
+    status: str
+    message: str

--- a/backend-api/app/schemas/scan.py
+++ b/backend-api/app/schemas/scan.py
@@ -101,3 +101,34 @@ class ScanCreatedResponse(BaseModel):
     id: int
     status: str
     message: str
+
+class ControlCategoryBreakdown(BaseModel):
+    """Pass/fail counts grouped by control category prefix."""
+
+    category: str
+    total: int
+    passed: int
+    failed: int
+    skipped: int
+    error: int
+
+
+class ScanSummary(BaseModel):
+    """Lightweight scan summary without full result detail."""
+
+    id: int
+    status: str
+    framework: str
+    benchmark: str
+    version: str
+    started_at: datetime
+    finished_at: datetime | None
+    compliance_score: Decimal | None
+    total_controls: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    error_count: int
+    categories: list[ControlCategoryBreakdown]
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Added a new GET /scans/{scan_id}/summary endpoint to the scans API. The existing GET /scans/{scan_id} endpoint returns the full scan with all results embedded, which gets heavier as control counts grow. The new summary endpoint returns just the compliance score, pass/fail/skipped/error counts, and a breakdown grouped by control category prefix  making it useful for dashboard overview views where you want fast, lightweight data before loading the full detail.
No existing endpoints were modified or broken. All changes are additive.
Discussed with David , agreed the summary endpoint is a useful standalone addition that the frontend can use to load overview data quickly before calling the detail endpoint asynchronously.
