### PR TITLE
26T1-ENG-RL-001 | fixed worker entrypoint file not found

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -21,8 +21,8 @@ COPY opa_client.py ./
 # Set Python path to include /app
 ENV PYTHONPATH=/app
 
-# Copy and run entrypoint
+# Copy entrypoint script and fix line endings
 COPY worker_entrypoint.sh .
-RUN chmod +x worker_entrypoint.sh
+RUN sed -i 's/\r$//' worker_entrypoint.sh && chmod +x worker_entrypoint.sh
 
 CMD ["./worker_entrypoint.sh"]


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Fix Dockerfile failing to build "./worker_entrypoint.sh"

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->
Scan engine failed to start due to `autoaudit-worker` failing to start, caused by `./worker_entrypoint.sh` file not found.

## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [ ] Tested manually — describe how:
- [x] No tests required — explain why: Finally works on my machine

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->
No security impact.

## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing
