### PR TITLE
Add error handling to Teams External Access collector

### DIFF
--- a/engine/collectors/_pending/teams/external_access_policy.py
+++ b/engine/collectors/_pending/teams/external_access_policy.py
@@ -39,7 +39,20 @@ class ExternalAccessPolicyDataCollector(BasePowerShellCollector):
             - external_access_policies: List of external access policies
             - global_policy: The global external access policy
         """
-        policies = await client.run_cmdlet("Teams", "Get-CsExternalAccessPolicy")
+        # Handle known MicrosoftTeams AccessToken authentication issue
+        # Returns structured failure output instead of breaking the collector
+        try:
+            policies = await client.run_cmdlet("Teams", "Get-CsExternalAccessPolicy")
+        except Exception as error:
+            return {
+                "external_access_policies": [],
+                "total_policies": 0,
+                "global_policy": None,
+                "status": "failed",
+                "reason": "MicrosoftTeams PowerShell AccessToken authentication not supported",
+                "error": str(error),
+                "recommendation": "Implement certificate-based authentication as described in _pending/README",
+            }
 
         # Handle single policy vs list
         if isinstance(policies, dict):


### PR DESCRIPTION


## Summary
Adds error handling to the Teams External Access Policy collector to handle AccessToken authentication failures gracefully.

Instead of crashing, the collector now returns a structured failure response with a clear reason and recommendation.


## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [x] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine (collectors / policies)`
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
The Teams External Access collector was failing due to a known issue with MicrosoftTeams PowerShell AccessToken authentication ("Not supported tenant type").

This change improves reliability by ensuring the collector handles authentication failures gracefully instead of crashing.


## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [x] Tested manually — used a mock client to simulate the authentication failure and confirmed the collector returns a structured response instead of crashing. This was validated using a simulated "Not supported tenant type" error to closely match the real failure scenario.
- [ ] No tests required — explain why:

## Security Considerations
No direct security impact. The change improves error handling and does not expose sensitive data.

## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
N/A — backend change, no UI impact.