### PR TITLE
Normalize framework name and control_id when building OPA package path

### DIFF
--- a/engine/tests/test_wiring.py
+++ b/engine/tests/test_wiring.py
@@ -49,10 +49,11 @@ _PACKAGE_RE = re.compile(r"^package\s+(\S+)", re.MULTILINE)
 
 def _expected_package(framework: str, slug: str, version: str, control_id: str) -> str:
     """Replicate the package-path logic from worker/tasks.py:380-395."""
+    framework_normalized = framework.replace("-", "_")
     benchmark_normalized = slug.replace("-", "_")
     version_normalized = version.replace(".", "_")
-    control_suffix = control_id.replace(".", "_")
-    return f"{framework}.{benchmark_normalized}.{version_normalized}.control_{control_suffix}"
+    control_suffix = control_id.replace(".", "_").replace("-", "_").lower()
+    return f"{framework_normalized}.{benchmark_normalized}.{version_normalized}.control_{control_suffix}"
 
 
 def _extract_rego_package(rego_path: Path) -> str | None:

--- a/engine/worker/tasks.py
+++ b/engine/worker/tasks.py
@@ -382,17 +382,19 @@ async def _evaluate_control_async(
     # OPA REST API path: "cis/microsoft_365_foundations/v3_1_0/control_1_1_1"
     #
     # Transform:
+    # - framework: "essential-eight" -> "essential_eight"
     # - benchmark: "microsoft-365-foundations" -> "microsoft_365_foundations"
     # - version: "v3.1.0" -> "v3_1_0"
-    # - control_id: "1.1.1" -> "control_1_1_1"
+    # - control_id: "1.1.1" -> "control_1_1_1", "E8-MAC-2.1" -> "control_e8_mac_2_1"
+    framework_normalized = framework.replace("-", "_")
     benchmark_normalized = benchmark.replace("-", "_")
     version_normalized = version.replace(".", "_")
 
-    # Convert control_id like "1.1.1" to "control_1_1_1"
-    control_suffix = control_id.replace(".", "_")
+    # Convert control_id to a valid Rego identifier (lowercase, hyphens/dots to underscores)
+    control_suffix = control_id.replace(".", "_").replace("-", "_").lower()
     control_package = f"control_{control_suffix}"
 
-    package_path = f"{framework}/{benchmark_normalized}/{version_normalized}/{control_package}"
+    package_path = f"{framework_normalized}/{benchmark_normalized}/{version_normalized}/{control_package}"
 
     # Evaluate policy with OPA
     result = await opa_client.evaluate_policy(package_path, collected_data)


### PR DESCRIPTION
## Summary
Fixes a bug in OPA package-path construction that prevented E8 controls from being evaluated. The path-builder did not normalize framework names or handle hyphens/uppercase in control IDs, so 'essential-eight' / 'E8-MAC-2.1' produced an invalid Rego package path.



## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
While building the E8-MAC-2.1 control (Win32 API call blocking ASR rule), every scan returned the generic Rego fallback message ("Unable to determine ...") regardless of the underlying Intune state. Investigation showed the engine was constructing an OPA package path that didn't match any loaded Rego module:                                                                  
                  
  **Before:** 'essential-eight/asd_essential_eight/v2025/control_E8-MAC-2_1'                    
  **After:**  'essential_eight/asd_essential_eight/v2025/control_e8_mac_2_1'
                                                                                                 
  Three issues were fixed:
  1. The framework name (`essential-eight`) was not normalized — hyphens are illegal in Rego     
  package identifiers.                                                                           
  2. The control_id transform did not handle hyphens (`E8-MAC-2.1` kept its hyphens).
  3. The control_id transform did not lowercase, so uppercase letters survived into the Rego     
  identifier.                                                                                    
                                                                                                 
  This fix unblocks the entire ASD Essential Eight framework — every E8 control authored by the  
  team relies on it.


## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [x] Tested manually — describe how:

Ran a CIS Microsoft 365 Foundations scan before and after the change. 
-> Same controls passed/failed in both runs ; confirms the change is backwards-compatible (no CIS regression).  
Ran an ASD Essential Eight scan with E8-MAC-2.1. 
-> Before the fix: generic OPA fallback message. After the fix: correct PASS when the Intune ASR rule is set to Block, correct FAIL with a meaningful message when it is not.

- [ ] No tests required — explain why:

## Security Considerations
No security impact. The change only normalizes string formatting for an internal HTTP path between the worker and OPA. No auth, secrets, API permissions, or data exposure are affected.

## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:

The added transforms are no-ops on existing CIS inputs:                                        
  -> `"cis".replace("-", "_")` → `"cis"`
  -> `"1.1.1".replace("-", "_").lower()` → `"1_1_1"`

## Rollback Plan
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
<img width="1794" height="495" alt="image" src="https://github.com/user-attachments/assets/2d893a69-060e-43d1-96dc-a83d9d568270" />
