### PR TITLE
Improve mobile responsiveness for assigned pages

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 //Last updated 17 September 2025
 //Added theme support
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import {
   LayoutDashboard,
@@ -95,7 +95,10 @@ type SidebarProps = {
 const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode = true }) => {
   const navigate = useNavigate();
   const location = useLocation();
-
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth < 768;
+  });
   const [isExpanded, setIsExpanded] = useState<boolean>(() => {
     if (typeof window === "undefined") return true;
     try {
@@ -108,6 +111,20 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
   });
 
   const [searchValue, setSearchValue] = useState<string>("");
+    useEffect(() => {
+    const handleResize = () => {
+      const mobile = window.innerWidth < 768;
+      setIsMobile(mobile);
+      onWidthChange(mobile ? 0 : isExpanded ? 220 : 80);
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, [isExpanded, onWidthChange]);
+
+  const effectiveExpanded = isMobile ? false : isExpanded;
 
   const getActiveItem = (): "home" | "cloud-platforms" | "scans" | "tasks" | "reports" | "settings" | "account" => {
     const path = location.pathname;
@@ -123,10 +140,10 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
 
   const activeItem = getActiveItem();
 
-  const toggleSidebar = (): void => {
+    const toggleSidebar = (): void => {
     const newExpanded = !isExpanded;
     setIsExpanded(newExpanded);
-    onWidthChange(newExpanded ? 220 : 80);
+    onWidthChange(isMobile ? 0 : newExpanded ? 220 : 80);
     if (typeof window !== "undefined") {
       try {
         window.localStorage.setItem(SIDEBAR_EXPANDED_KEY, String(newExpanded));
@@ -151,12 +168,12 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
   return (
     <nav
       className={`fixed left-0 top-0 z-1000 h-screen overflow-x-hidden overflow-y-hidden transition-[width,background-color] duration-300 ${
-        isExpanded ? "w-55" : "w-20"
+                effectiveExpanded ? "w-55" : "w-20"
       } ${sidebarTheme}`}
     >
       <div className="flex flex-col items-center pt-5 w-full h-screen px-3.75 pb-7.5">
         <div className="flex justify-center mb-10 w-full">
-          {isExpanded ? (
+                    {effectiveExpanded ? (
             <div
               className={`flex w-full max-w-47.5 items-center rounded-[25px] p-2 transition-all duration-300 hover:-translate-y-0.5 max-md:max-w-37.5 ${
                 isDarkMode
@@ -210,7 +227,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/dashboard"}
             name={"Dashboard"}
             icon={LayoutDashboard}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "home"}
             onClick={() => handleNavClick("/dashboard")}
@@ -219,7 +236,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/cloud-platforms"}
             name={"Cloud Platforms"}
             icon={Cloud}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "cloud-platforms"}
             onClick={() => handleNavClick("/cloud-platforms")}
@@ -228,7 +245,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/scans"}
             name={"Scans"}
             icon={FileSearch}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "scans"}
             onClick={() => handleNavClick("/scans")}
@@ -237,7 +254,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/evidence-scanner"}
             name={"Evidence"}
             icon={ShieldCheck}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "tasks"}
             onClick={() => handleNavClick("/evidence-scanner")}
@@ -253,7 +270,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/settings"}
             name={"Settings"}
             icon={Settings}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "settings"}
             onClick={() => handleNavClick("/settings")}
@@ -262,7 +279,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onWidthChange = () => {}, isDarkMode 
             href={"/account"}
             name={"Account"}
             icon={User}
-            isExpanded={isExpanded}
+            isExpanded={effectiveExpanded}
             isDarkMode={isDarkMode}
             isActive={activeItem === "account"}
             onClick={() => handleNavClick("/account")}

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -60,13 +60,13 @@ export default function AccountPage({
         isDarkMode ? "bg-slate-900 text-white" : "bg-gray-100 text-black"
       }`}
       style={{
-        marginLeft: `${sidebarWidth}px`,
-        width: `calc(100% - ${sidebarWidth}px)`,
-      }}
+  marginLeft: sidebarWidth ? `${sidebarWidth}px` : 0,
+  width: sidebarWidth ? `calc(100% - ${sidebarWidth}px)` : "100%",
+}}
     >
-      <div className="p-6 mx-auto max-w-4xl">
+      <div className="p-4 pl-24 mx-auto max-w-4xl sm:p-6 sm:pl-6">
         {/* HEADER */}
-        <div className="flex justify-between items-center mb-8">
+        <div className="flex flex-col gap-4 items-start mb-8 sm:flex-row sm:justify-between sm:items-center">
           <div className="flex gap-3 items-center">
             <User size={24} />
             <div>
@@ -81,7 +81,7 @@ export default function AccountPage({
             type="button"
             onClick={handleLogout}
             disabled={isLoggingOut}
-            className="flex gap-2 items-center py-2 px-4 bg-red-600 rounded-lg transition hover:bg-red-700 disabled:opacity-50"
+            className="flex gap-2 justify-center items-center py-2 px-4 w-full bg-red-600 rounded-lg transition sm:w-auto hover:bg-red-700 disabled:opacity-50"
           >
             {isLoggingOut ? (
               <>

--- a/frontend/src/pages/Evidence.tsx
+++ b/frontend/src/pages/Evidence.tsx
@@ -323,18 +323,18 @@ const Evidence = ({ sidebarWidth = 220, isDarkMode = true }: EvidencePageProps) 
 
   return (
     <div
-      className={`${isDarkMode ? 'dark' : 'light'} min-h-screen p-6 bg-surface-1 text-text-strong transition-colors duration-200 in-[.light]:bg-surface-1`}
+      className={`${isDarkMode ? 'dark' : 'light'} min-h-screen p-4 pl-24 bg-surface-1 text-text-strong transition-colors duration-200 sm:p-6 sm:pl-6 in-[.light]:bg-surface-1`}
       style={{
-        // Layout: keep page content aligned with collapsible sidebar width.
-        marginLeft: `${sidebarWidth}px`,
-        width: `calc(100% - ${sidebarWidth}px)`,
-        transition: 'margin-left 0.4s ease, width 0.4s ease'
-      }}
+  // Layout: keep desktop aligned with sidebar, but allow full width on mobile.
+  marginLeft: sidebarWidth ? `${sidebarWidth}px` : 0,
+  width: sidebarWidth ? `calc(100% - ${sidebarWidth}px)` : '100%',
+  transition: 'margin-left 0.4s ease, width 0.4s ease'
+}}
     >
       <div className="mx-auto w-full max-w-300">
-        <div className="flex gap-5 justify-start items-center pl-6 mb-1.5">
-          <div className="flex gap-5 items-center">
-            <img src="/AutoAudit.png" alt="AutoAudit Logo" className="object-contain w-40 h-40" />
+        <div className="flex justify-start items-center mb-1.5 sm:pl-6">
+          <div className="flex flex-col gap-2 items-start sm:flex-row sm:gap-5 sm:items-center">
+            <img src="/AutoAudit.png" alt="AutoAudit Logo" className="object-contain w-24 h-24 sm:w-40 sm:h-40" />
             <h1
               className="m-0 font-bold tracking-wide leading-none text-accent-teal in-[.light]:text-brand-blue"
               style={{
@@ -347,7 +347,7 @@ const Evidence = ({ sidebarWidth = 220, isDarkMode = true }: EvidencePageProps) 
           </div>
         </div>
 
-        <p className="mt-1.5 mb-6 ml-6 leading-snug text-left text-text-muted text-[15px]">
+        <p className="mt-1.5 mb-6 leading-snug text-left text-text-muted text-[15px] sm:ml-6">
           Your Evidence Assistant: Pick a strategy and upload your file. Images, PDF, DOCX, TXT, logs, registry exports
           are supported.
         </p>
@@ -415,7 +415,7 @@ const Evidence = ({ sidebarWidth = 220, isDarkMode = true }: EvidencePageProps) 
 
           <div className="flex flex-wrap gap-3 items-center mt-6">
             <button
-              className="flex gap-2 items-center py-3 px-5 font-semibold border transition-all duration-300 cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed rounded-[10px] text-[15px] bg-accent-teal text-accent-navy border-accent-teal hover:bg-brand-cyan hover:border-brand-cyan hover:shadow-[0_4px_12px_rgb(var(--brand-cyan))] disabled:hover:bg-brand-cyan disabled:hover:border-brand-cyan"
+              className="flex gap-2 justify-center items-center py-3 px-5 w-full font-semibold border transition-all duration-300 cursor-pointer sm:w-auto disabled:opacity-60 disabled:cursor-not-allowed rounded-[10px] text-[15px] bg-accent-teal text-accent-navy border-accent-teal hover:bg-brand-cyan hover:border-brand-cyan hover:shadow-[0_4px_12px_rgb(var(--brand-cyan))] disabled:hover:bg-brand-cyan disabled:hover:border-brand-cyan"
               // Disable until strategy + file selected (and while scanning).
               disabled={!selectedStrategy || !selectedFile || isScanning}
               onClick={handleScan}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -69,12 +69,12 @@ export default function SettingsPage({ sidebarWidth = 220, isDarkMode = true }: 
 
   return (
     <div
-      className={`min-h-screen bg-surface-1 p-6 text-text-strong transition-colors duration-300 ${!isDarkMode ? "light" : ""}`}
+      className={`min-h-screen bg-surface-1 p-4 pl-24 text-text-strong transition-colors duration-300 sm:p-6 sm:pl-6 ${!isDarkMode ? "light" : ""}`}
       style={{
-        marginLeft: `${sidebarWidth}px`,
-        width: `calc(100% - ${sidebarWidth}px)`,
-        transition: "margin-left 0.4s ease, width 0.4s ease",
-      }}
+  marginLeft: sidebarWidth ? `${sidebarWidth}px` : 0,
+  width: sidebarWidth ? `calc(100% - ${sidebarWidth}px)` : "100%",
+  transition: "margin-left 0.4s ease, width 0.4s ease",
+    }}
     >
       <div className="flex flex-col gap-6 mx-auto max-w-250">
         <div className="flex justify-between items-center">
@@ -133,18 +133,15 @@ export default function SettingsPage({ sidebarWidth = 220, isDarkMode = true }: 
               </label>
             </div>
 
-            <div className="flex flex-wrap gap-3 justify-end mt-4">
+            <div className="flex flex-col gap-3 mt-4 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="inline-flex gap-2 justify-center items-center py-2 px-4 text-sm font-medium rounded-lg border transition-all duration-300 hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed border-border-subtle bg-surface-2 text-text-strong hover:bg-border-subtle disabled:hover:translate-y-0"
-                onClick={handleReset}
-                disabled={!hasChanges || isSaving}
-              >
+                className="inline-flex gap-2 justify-center items-center py-2 px-4 w-full text-sm font-medium rounded-lg border transition-all duration-300 sm:w-auto hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed border-border-subtle bg-surface-2 text-text-strong hover:bg-border-subtle disabled:hover:translate-y-0">
                 Reset
               </button>
               <button
                 type="button"
-                className="inline-flex gap-2 justify-center items-center py-2 px-4 text-sm font-semibold text-white rounded-lg border shadow-lg transition-all duration-300 hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed border-[rgb(var(--accent-teal)/0.4)] bg-accent-teal hover:brightness-105 disabled:hover:translate-y-0"
+                className="inline-flex gap-2 justify-center items-center py-2 px-4 w-full text-sm font-semibold text-white rounded-lg border shadow-lg transition-all duration-300 sm:w-auto hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed border-[rgb(var(--accent-teal)/0.4)] bg-accent-teal hover:brightness-105 disabled:hover:translate-y-0"
                 onClick={handleSave}
                 disabled={!hasChanges || isSaving}
               >


### PR DESCRIPTION
## Summary
Improved mobile responsiveness for the assigned frontend pages:
- Settings
- Account
- Evidence Scanner

Also updated the sidebar behaviour on mobile so it stays icon-only and does not take up the full sidebar width. This gives the page content more usable space on smaller screens instead of being squeezed.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
- [ ] `/backend-api`
- [x] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
This change was needed after the TailwindCSS migration to improve the mobile layout for dashboard-related pages.

On smaller screens, the sidebar was taking too much horizontal space and the page content was being squeezed. The update keeps the sidebar icon-only on mobile and improves spacing/layout for Settings, Account, and Evidence Scanner.

## Testing Done
- [ ] Unit tests pass locally
- [x] Tested manually — describe how:
Rebuilt the frontend using Docker and tested the Settings, Account, and Evidence Scanner pages in mobile view using browser developer tools. Checked that the sidebar no longer takes up the full width on mobile and that the page content has proper space.
- [ ] No tests required — explain why:

## Security Considerations
No auth flow, secrets, credentials, API permissions, or sensitive data handling were changed in this PR.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes — describe below:

## Rollback Plan
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
Mobile responsiveness screenshots for Settings, Account, and Evidence Scanner can be attached for visual review.
<img width="1710" height="1112" alt="Screenshot 2026-05-07 at 12 33 17 AM" src="https://github.com/user-attachments/assets/675057df-e982-4785-be7c-ac3990f3f4f7" />

<img width="1710" height="1112" alt="Screenshot 2026-05-07 at 12 33 47 AM" src="https://github.com/user-attachments/assets/da8ea29f-4141-43a6-80c8-f4d585979165" />

<img width="1710" height="1112" alt="Screenshot 2026-05-07 at 12 34 02 AM" src="https://github.com/user-attachments/assets/807f2a39-4b83-481a-850b-c8c0b0644523" />
