### PR TITLE
Add markdown report documentation scoring tool

### DIFF
--- a/tools/score_report_doc_quality.py
+++ b/tools/score_report_doc_quality.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+
+SCORING_SECTIONS = {
+    "## Purpose": 25,
+    "## Starter Mapping": 25,
+    "## Future Opportunities": 25,
+    "## Conclusion": 25,
+}
+
+
+def calculate_score(file_path: Path) -> int:
+    if not file_path.exists():
+        print(f"Fail. File not found: {file_path}")
+        return 0
+
+    content = file_path.read_text(encoding="utf-8")
+    lines = {line.strip() for line in content.splitlines()}
+
+    score = 0
+
+    for section, points in SCORING_SECTIONS.items():
+        if section in lines:
+            score += points
+            print(f"Pass. Found {section} (+{points})")
+        else:
+            print(f"Miss. Missing {section} (+0)")
+
+    print(f"\nDocumentation Score: {score}/100")
+    return score
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python tools/score_report_doc_quality.py <markdown-file-path>")
+        return 1
+
+    score = calculate_score(Path(sys.argv[1]))
+
+    return 0 if score == 100 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/score_report_doc_quality.py
+++ b/tools/score_report_doc_quality.py
@@ -15,8 +15,10 @@ def calculate_score(file_path: Path) -> int:
         return 0
 
     content = file_path.read_text(encoding="utf-8")
-    lines = {line.strip() for line in content.splitlines()}
-
+    lines = [
+            line.strip().rstrip("#").strip()
+            for line in content.splitlines()
+            ]
     score = 0
 
     for section, points in SCORING_SECTIONS.items():


### PR DESCRIPTION
## Summary

This PR adds a Python utility script that scores markdown report documentation quality based on required report sections.

The tool checks whether a markdown file contains key report headings and calculates a documentation quality score out of 100.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
- [ ] `/backend-api`
- [ ] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [x] `/docs`

## Motivation

This tool supports GRC/reporting documentation consistency by giving contributors a simple score-based way to assess whether markdown report artefacts contain required sections.

## Testing Done
- [ ] Unit tests pass locally
- [x] Tested manually — describe how:
- [ ] No tests required — explain why:

Tested manually by running:

```powershell
python tools/score_report_doc_quality.py README.md