### PR TITLE
Add PR size warning workflow

### DIFF
--- a/.github/workflows/pr.size-warning.yml
+++ b/.github/workflows/pr.size-warning.yml
@@ -1,0 +1,43 @@
+name: "PR Size Warning"
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  pr-size:
+    name: PR size warning
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = pr.changed_files || 0;
+            const additions = pr.additions || 0;
+            const deletions = pr.deletions || 0;
+            const total = additions + deletions;
+
+            // Initial warning thresholds only.
+            // Chosen as a reasonable starting point to flag unusually large PRs
+            // without blocking normal development work.
+            const fileWarn = 30;
+            const lineWarn = 500;
+
+            if (files > fileWarn || total > lineWarn) {
+              core.warning(
+                `PR is large: ${files} files, ${additions} additions, ${deletions} deletions (${total} total). ` +
+                `Consider splitting it into smaller PRs where possible.`
+              );
+            } else {
+              core.info(
+                `PR size OK: ${files} files, ${additions} additions, ${deletions} deletions (${total} total).`
+              );
+            }


### PR DESCRIPTION
## Summary

Adds an initial PR size warning workflow for the AutoAudit repository.

The workflow runs on pull requests to `main` and gives a warning when a PR becomes unusually large based on:

* changed files
* total line changes

## Why warning only

This first version is warning-only rather than blocking so it stays low-risk and can be observed safely before any stricter enforcement is considered.

## Thresholds used

* 30 changed files
* 500 total line changes

These were chosen as a starting point to flag unusually large PRs without creating too much noise for normal work.

## Testing

I tested this workflow safely in my fork before opening this PR by:

* adding the workflow to `.github/workflows/pr.size-warning.yml`
* creating a separate test branch
* opening a pull request in the fork back into `main`
* triggering the warning with a large dummy test file

The workflow ran successfully and returned the expected PR size warning.

## File added

* `.github/workflows/pr.size-warning.yml`
