### PR TITLE
Pause dependabot PR's setting open-pull-requests-limit to 0 from 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,31 @@ updates:
     directory: "/backend-api"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "uv"
     directory: "/engine"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/security"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "docker"
     directory: "/backend-api"


### PR DESCRIPTION
Pause dependabot PR's setting open-pull-requests-limit to 0 from 5. To be changed at a later date.

## Summary
<!-- What does this PR do? -->


## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->


## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [ ] Tested manually — describe how:
- [ ] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [ ] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [ ] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [ ] Code follows project conventions
- [ ] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [ ] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
