### PR TITLE
Implement CIS control 1.3.3: Ensure 'External sharing' of calendars is not available

### DIFF
--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.3_external_calendar_sharing_restricted.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.3_external_calendar_sharing_restricted.rego
@@ -1,0 +1,54 @@
+# METADATA
+# title: Ensure 'External sharing' of calendars is not available
+# description: |
+#   External calendar sharing policies should not be enabled. Enabled policies
+#   that define external domains allow free/busy details to be shared outside
+#   the organization.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-1.3.3
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: medium
+#   service: Exchange
+#   requires_permissions:
+#   - Exchange.Manage
+
+package cis.microsoft_365_foundations.v6_0_0.control_1_3_3
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := output if {
+	policies_allowing_external := object.get(input, "policies_allowing_external", [])
+
+	enabled_external_policies := [p |
+		some p in policies_allowing_external
+		p.enabled == true
+	]
+
+	compliant := count(enabled_external_policies) == 0
+
+	output := {
+		"compliant": compliant,
+		"message": generate_message(compliant, enabled_external_policies),
+		"affected_resources": generate_affected_resources(enabled_external_policies),
+		"details": {
+			"policies_allowing_external": policies_allowing_external,
+			"enabled_external_policies": enabled_external_policies,
+		},
+	}
+}
+
+generate_message(true, _) := "No sharing policies allow external calendar sharing"
+
+generate_message(false, enabled_external_policies) := msg if {
+	count(enabled_external_policies) > 0
+	msg := sprintf("%d sharing policy(ies) allow external calendar sharing", [count(enabled_external_policies)])
+}
+
+generate_affected_resources(enabled_external_policies) := [p.name |
+	some p in enabled_external_policies
+]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -136,9 +136,9 @@
       "level": "L2",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "exchange.organization.sharing_policy",
-      "policy_file": null,
+      "policy_file": "1.3.3_external_calendar_sharing_restricted.rego",
       "requires_permissions": ["Exchange.Manage"],
       "notes": "Collector exists but control logic not defined"
     },

--- a/engine/tests/test_cis_1_3_3_external_calendar_sharing.rego
+++ b/engine/tests/test_cis_1_3_3_external_calendar_sharing.rego
@@ -1,0 +1,99 @@
+package cis.microsoft_365_foundations.v6_0_0.test_control_1_3_3
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Helpers: build minimal policy entries matching what the collector emits
+# ---------------------------------------------------------------------------
+
+_policy_external_disabled := {
+	"name": "Default Sharing Policy",
+	"domains": ["*:CalendarSharingFreeBusySimple", "Anonymous:CalendarSharingFreeBusyReviewer"],
+	"enabled": false,
+}
+
+_policy_external_enabled := {
+	"name": "Default Sharing Policy",
+	"domains": ["*:CalendarSharingFreeBusySimple"],
+	"enabled": true,
+}
+
+_second_policy_external_enabled := {
+	"name": "Custom External Policy",
+	"domains": ["Anonymous:CalendarSharingFreeBusyReviewer"],
+	"enabled": true,
+}
+
+# ---------------------------------------------------------------------------
+# Test: compliant — no sharing policies at all
+# ---------------------------------------------------------------------------
+
+test_compliant_no_policies if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": []}
+	result.compliant == true
+	contains(result.message, "No sharing policies")
+}
+
+# ---------------------------------------------------------------------------
+# Test: compliant — external policy exists but is disabled
+# ---------------------------------------------------------------------------
+
+test_compliant_external_policy_disabled if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": [_policy_external_disabled]}
+	result.compliant == true
+	count(result.details.enabled_external_policies) == 0
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — one enabled policy allows external sharing
+# ---------------------------------------------------------------------------
+
+test_non_compliant_one_enabled_policy if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": [_policy_external_enabled]}
+	result.compliant == false
+	count(result.details.enabled_external_policies) == 1
+	contains(result.message, "1 sharing policy")
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — multiple enabled policies, affected resources listed
+# ---------------------------------------------------------------------------
+
+test_non_compliant_multiple_enabled_policies if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": [_policy_external_enabled, _second_policy_external_enabled]}
+	result.compliant == false
+	count(result.details.enabled_external_policies) == 2
+	count(result.affected_resources) == 2
+}
+
+# ---------------------------------------------------------------------------
+# Test: mixed — one enabled and one disabled, only enabled counts
+# ---------------------------------------------------------------------------
+
+test_mixed_enabled_and_disabled_policies if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": [_policy_external_disabled, _policy_external_enabled]}
+	result.compliant == false
+	count(result.details.enabled_external_policies) == 1
+}
+
+# ---------------------------------------------------------------------------
+# Test: missing data — field absent entirely, treated as no external sharing
+# ---------------------------------------------------------------------------
+
+test_missing_policies_field if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {}
+	result.compliant == true
+}
+
+# ---------------------------------------------------------------------------
+# Test: result structure contains expected fields
+# ---------------------------------------------------------------------------
+
+test_result_structure if {
+	result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_3.result with input as {"policies_allowing_external": [_policy_external_enabled]}
+	_ = result.compliant
+	_ = result.message
+	_ = result.affected_resources
+	_ = result.details.policies_allowing_external
+	_ = result.details.enabled_external_policies
+}


### PR DESCRIPTION
## Summary
Implements the Rego policy for CIS Microsoft 365 Foundations control 1.3.3 
(Ensure 'External sharing' of calendars is not available).

- The collector (exchange.organization.sharing_policy) already existed - no collector changes needed
- New Rego policy evaluates sharing policies and only counts policies that are BOTH 
  enabled AND have external domains configured (a disabled policy with domains defined 
  is still compliant)
- Unit tests: 7/7 passing, covering compliant, non-compliant, mixed enabled/disabled, 
  and missing-data cases
- metadata.json updated: automation_status not_started -> ready, policy_file linked

## Testing
- OPA unit tests: 7/7 PASS
- Collector tested against the shared test tenant: returns Default Sharing Policy 
  with enabled=false -> policy correctly evaluates compliant=true