### PR TITLE
feat(api): add readiness & health endpoint 

### DIFF
--- a/backend-api/app/main.py
+++ b/backend-api/app/main.py
@@ -5,6 +5,7 @@ from app.api.v1.router import api_router
 from app.core.config import get_settings
 from app.core.middleware import RequestLoggingMiddleware
 from app.core.errors import not_found_handler, NotFound
+from app.schemas.health import ReadinessResponse
 settings = get_settings()
 
 
@@ -39,7 +40,17 @@ def create_app() -> FastAPI:
         return {
             "status": "healthy",
         }
-        
+
+    @app.get(
+        "/readiness",
+        response_model=ReadinessResponse,
+        tags=["Health"],
+        summary="Check whether the API is ready to serve requests",
+    )
+    def readiness_check() -> ReadinessResponse:
+        return ReadinessResponse()
+
+
     return app
 
 app = create_app()

--- a/backend-api/app/schemas/health.py
+++ b/backend-api/app/schemas/health.py
@@ -1,0 +1,10 @@
+"""Response model for checking the health status of service endpoints."""
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ReadinessResponse(BaseModel):
+    """Response model used to indicate that the API is ready."""
+
+    status: Literal["ready"] = "ready"


### PR DESCRIPTION
## Summary

- Added a new `GET /readiness` endpoint for checking whether the API is ready to serve requests
- Added a `ReadinessResponse` Pydantic model to provide a clear and consistent response structure
- Grouped the new endpoint under the `Health` tag in the API documentation

## Testing

- Started the FastAPI backend locally
- Confirmed that `/readiness` returns HTTP 200
- Confirmed the response body is:

```json
{
  "status": "ready"
}
