### PR TITLE
26T2-BE-SS-001 — Intune Settings Catalog collector

### DIFF
--- a/engine/collectors/entra/devices/configuration_policies.py
+++ b/engine/collectors/entra/devices/configuration_policies.py
@@ -1,16 +1,16 @@
-"""Intune configuration policies collector.
+"""Intune Settings Catalog collector.
 
 Essential Eight Benchmark Controls:
     E8-MAC-1.1, E8-MAC-1.2, E8-MAC-1.3, E8-MAC-1.4 (ML1 — Settings Catalog)
-    E8-MAC-2.1 (ML2 — Legacy Device Configuration / ASR rules)
     E8-MAC-3.1, E8-MAC-3.3, E8-MAC-3.4 (ML3 — Settings Catalog)
+
+E8-MAC-2.1 (ML2 — ASR rules) is handled separately by the asr_rules collector.
 
 Connection Method: Microsoft Graph API
 Required Scopes: DeviceManagementConfiguration.Read.All
 Graph Endpoints:
     /beta/deviceManagement/configurationPolicies
     /beta/deviceManagement/configurationPolicies/{id}/settings
-    /v1.0/deviceManagement/deviceConfigurations
 """
 
 from typing import Any
@@ -20,23 +20,20 @@ from collectors.graph_client import GraphClient
 
 
 class ConfigurationPoliciesDataCollector(BaseDataCollector):
-    """Collects Intune configuration policies for Essential Eight compliance evaluation.
+    """Collects Intune Settings Catalog policies for Essential Eight compliance evaluation.
 
     Retrieves Settings Catalog policies (VBA macro settings, AMSI scanning,
-    internet macro blocking, V3 signatures) and Legacy Device Configuration
-    profiles (ASR rules) needed to assess ASD Essential Eight Macro Settings
-    controls across ML1-ML3.
+    internet macro blocking, signed-macro enforcement) needed to assess ASD
+    Essential Eight Macro Settings controls at ML1 and ML3.
     """
 
     async def collect(self, client: GraphClient) -> dict[str, Any]:
-        """Collect Intune configuration policy data.
+        """Collect Intune Settings Catalog policy data.
 
         Returns:
             Dict containing:
             - configuration_policies: Settings Catalog policies with their settings
             - total_configuration_policies: Count of Settings Catalog policies
-            - device_configurations: Legacy Device Configuration profiles (includes ASR rules)
-            - total_device_configurations: Count of Legacy Device Configuration profiles
         """
         # Settings Catalog policies — covers ML1 (E8-MAC-1.1 to 1.4) and ML3 controls
         policies = await client.get_all_pages(
@@ -61,17 +58,7 @@ class ConfigurationPoliciesDataCollector(BaseDataCollector):
                 "settings": settings,
             })
 
-        # Legacy Device Configuration profiles — covers ML2 (E8-MAC-2.1, ASR rules).
-        # Uses v1.0 endpoint, not beta. ASR rule state (block/audit/off) is readable
-        # directly from the windowsDefenderAdvancedThreatProtectionConfiguration object.
-        device_configurations = await client.get_all_pages(
-            "/deviceManagement/deviceConfigurations",
-            beta=False,
-        )
-
         return {
             "configuration_policies": policies_with_settings,
             "total_configuration_policies": len(policies_with_settings),
-            "device_configurations": device_configurations,
-            "total_device_configurations": len(device_configurations),
         }

--- a/engine/collectors/entra/devices/configuration_policies.py
+++ b/engine/collectors/entra/devices/configuration_policies.py
@@ -1,0 +1,77 @@
+"""Intune configuration policies collector.
+
+Essential Eight Benchmark Controls:
+    E8-MAC-1.1, E8-MAC-1.2, E8-MAC-1.3, E8-MAC-1.4 (ML1 — Settings Catalog)
+    E8-MAC-2.1 (ML2 — Legacy Device Configuration / ASR rules)
+    E8-MAC-3.1, E8-MAC-3.3, E8-MAC-3.4 (ML3 — Settings Catalog)
+
+Connection Method: Microsoft Graph API
+Required Scopes: DeviceManagementConfiguration.Read.All
+Graph Endpoints:
+    /beta/deviceManagement/configurationPolicies
+    /beta/deviceManagement/configurationPolicies/{id}/settings
+    /v1.0/deviceManagement/deviceConfigurations
+"""
+
+from typing import Any
+
+from collectors.base import BaseDataCollector
+from collectors.graph_client import GraphClient
+
+
+class ConfigurationPoliciesDataCollector(BaseDataCollector):
+    """Collects Intune configuration policies for Essential Eight compliance evaluation.
+
+    Retrieves Settings Catalog policies (VBA macro settings, AMSI scanning,
+    internet macro blocking, V3 signatures) and Legacy Device Configuration
+    profiles (ASR rules) needed to assess ASD Essential Eight Macro Settings
+    controls across ML1-ML3.
+    """
+
+    async def collect(self, client: GraphClient) -> dict[str, Any]:
+        """Collect Intune configuration policy data.
+
+        Returns:
+            Dict containing:
+            - configuration_policies: Settings Catalog policies with their settings
+            - total_configuration_policies: Count of Settings Catalog policies
+            - device_configurations: Legacy Device Configuration profiles (includes ASR rules)
+            - total_device_configurations: Count of Legacy Device Configuration profiles
+        """
+        # Settings Catalog policies — covers ML1 (E8-MAC-1.1 to 1.4) and ML3 controls
+        policies = await client.get_all_pages(
+            "/deviceManagement/configurationPolicies",
+            beta=True,
+        )
+
+        # Fetch the configured setting values for each policy individually.
+        # The top-level policy list only returns metadata (name, description, assignments).
+        # The actual setting IDs and values are in a separate per-policy endpoint.
+        policies_with_settings = []
+        for policy in policies:
+            policy_id = policy.get("id")
+            if not policy_id:
+                continue
+            settings = await client.get_all_pages(
+                f"/deviceManagement/configurationPolicies/{policy_id}/settings",
+                beta=True,
+            )
+            policies_with_settings.append({
+                **policy,
+                "settings": settings,
+            })
+
+        # Legacy Device Configuration profiles — covers ML2 (E8-MAC-2.1, ASR rules).
+        # Uses v1.0 endpoint, not beta. ASR rule state (block/audit/off) is readable
+        # directly from the windowsDefenderAdvancedThreatProtectionConfiguration object.
+        device_configurations = await client.get_all_pages(
+            "/deviceManagement/deviceConfigurations",
+            beta=False,
+        )
+
+        return {
+            "configuration_policies": policies_with_settings,
+            "total_configuration_policies": len(policies_with_settings),
+            "device_configurations": device_configurations,
+            "total_device_configurations": len(device_configurations),
+        }

--- a/engine/collectors/registry.py
+++ b/engine/collectors/registry.py
@@ -35,6 +35,9 @@ from collectors.entra.conditional_access.e8_mfa_enforcement import (
 
 # Devices
 from collectors.entra.devices.asr_rules import ASRRulesDataCollector
+from collectors.entra.devices.configuration_policies import (
+    ConfigurationPoliciesDataCollector,
+)
 from collectors.entra.devices.device_management_settings import (
     DeviceManagementSettingsDataCollector,
 )
@@ -155,6 +158,7 @@ DATA_COLLECTORS: dict[str, type[BaseDataCollector]] = {
     "entra.conditional_access.e8_mfa_enforcement": E8MfaEnforcementDataCollector,
     # Devices
     "entra.devices.asr_rules": ASRRulesDataCollector,
+    "entra.devices.configuration_policies": ConfigurationPoliciesDataCollector,
     "entra.devices.device_management_settings": DeviceManagementSettingsDataCollector,
     "entra.devices.device_registration_policy": DeviceRegistrationPolicyDataCollector,
     "entra.devices.enrollment_restrictions": EnrollmentRestrictionsDataCollector,

--- a/engine/policies/essential-eight/asd-essential-eight/v2025/metadata.json
+++ b/engine/policies/essential-eight/asd-essential-eight/v2025/metadata.json
@@ -32,7 +32,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -49,7 +49,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -66,7 +66,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -83,7 +83,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -117,7 +117,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -149,7 +149,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"
@@ -166,7 +166,7 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "not_started",
-      "data_collector_id": null,
+      "data_collector_id": "entra.devices.configuration_policies",
       "policy_file": null,
       "requires_permissions": [
         "DeviceManagementConfiguration.Read.All"


### PR DESCRIPTION
## Summary
Adds 'entra.devices.configuration_policies', a collector that reads Intune Settings Catalog policies and their configured setting values via Microsoft Graph ('/beta/deviceManagement/configurationPolicies' + per-policy '/settings'). This is the missing data source for the Essential Eight Macro Settings controls that live in the Settings Catalog (E8-MAC-1.1–1.4, 3.1), building on the single ASR-based check (2.1) already shipped. Scoped to the Settings Catalog only,  E8-MAC-2.1 stays with the existing 'asr_rules' collector, and the redundant legacy 'deviceConfigurations' fetch was removed so the two don't overlap.


## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
- [ ] `/backend-api`
- [ ] `/frontend`
- [X] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
AutoAudit can't currently read Intune Settings Catalog data, so the Essential Eight Macro Settings controls beyond the ASR rule have no data source and stay unautomated. This collector provides that source, unlocking E8-MAC-1.1–1.4 and 3.1 for the follow-on Rego work (BE-SS-002 onward).

## Testing Done
- [ ] Unit tests pass locally
- [X] Tested manually — describe how:

Ran against a sandbox M365 tenant via 'scripts.test_collector'. Authenticated and completed in ~2.7s, returning a macro Settings Catalog policy with all 7 configured settings across Word/Excel/PowerPoint. Used the output to confirm the real Graph setting IDs, which differed from prior guesses in two ways: (1) VBA-warnings and internet-block IDs are per Office app, not a shared 'office16v2' base; (2) VBA and AMSI values are nested (compliant value sits in 'choiceSettingValue.children[0]', not the top level). 

- [ ] No tests required — explain why:

## Security Considerations
Requires a new read-only Graph application permission ('DeviceManagementConfiguration.Read.All'). No secrets, credentials, or tokens committed. The collector only reads Intune configuration; no writes, no data exposure, no auth/RBAC changes.

## Breaking Changes
- [X] No breaking changes
Purely additive, a new collector plus one registry entry. Existing scans and collectors are unaffected.

- [ ] Yes — describe below:


## Rollback Plan
- [X] Revert commit is sufficient
No DB migrations. Reverting the commits removes the collector and its registry entry cleanly.

- [ ] Requires additional steps — describe below:

## Checklist
- [X] Code follows project conventions
- [X] No secrets, credentials, or tokens committed
- [X] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [X] PR is focused on one thing

## Screenshots

<img width="1789" height="937" alt="image" src="https://github.com/user-attachments/assets/d207f95d-a812-412f-90bd-c378a8f43829" />

<img width="1746" height="923" alt="image" src="https://github.com/user-attachments/assets/f66ddc78-d3ec-4e7b-8420-9a17f4eb8983" />

<img width="1712" height="475" alt="image" src="https://github.com/user-attachments/assets/ba2a1f8d-1b44-4ade-860b-4d7fa0828140" />

