### PR TITLE
Implement CIS 1.3.6 Customer Lockbox policy and tests

### DIFF
--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.6_customer_lockbox_enabled.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.6_customer_lockbox_enabled.rego
@@ -1,0 +1,25 @@
+package cis.microsoft_365_foundations.v6_0_0.control_1_3_6
+
+import rego.v1
+
+default result := {
+    "compliant": false,
+    "message": "Evaluation failed: unable to verify Customer Lockbox status",
+    "details": {}
+}
+
+result := {
+    "compliant": true,
+    "message": "Customer Lockbox is enabled",
+    "details": {"customer_lockbox_enabled": true}
+} if {
+    input.customer_lockbox_enabled == true
+}
+
+result := {
+    "compliant": false,
+    "message": "Customer Lockbox is not enabled",
+    "details": {"customer_lockbox_enabled": false}
+} if {
+    input.customer_lockbox_enabled == false
+}

--- a/engine/tests/test_cis_1_3_6_customer_lockbox_enabled.rego
+++ b/engine/tests/test_cis_1_3_6_customer_lockbox_enabled.rego
@@ -1,0 +1,29 @@
+package cis.microsoft_365_foundations.v6_0_0.test_control_1_3_6
+
+import rego.v1
+
+test_compliant_customer_lockbox_enabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_6.result with input as {
+        "customer_lockbox_enabled": true
+    }
+    result.compliant == true
+}
+
+test_non_compliant_customer_lockbox_disabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_6.result with input as {
+        "customer_lockbox_enabled": false
+    }
+    result.compliant == false
+}
+
+test_unknown_status_null if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_6.result with input as {
+        "customer_lockbox_enabled": null
+    }
+    result.compliant == false
+}
+
+test_missing_field if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_6.result with input as {}
+    result.compliant == false
+}


### PR DESCRIPTION
Implements the Rego policy and unit tests for CIS Microsoft 365 Foundations control 1.3.6 (Ensure the customer lockbox feature is enabled).

- Collector already existed (exchange.organization.organization_config) and already returns customer_lockbox_enabled — no collector changes were needed.
- Added policy file: 1.3.6_customer_lockbox_enabled.rego
- Added unit tests covering compliant, non-compliant, null, and missing-field cases — all 4 passing.
- Updated metadata.json: automation_status set to "ready", policy_file linked.

Note: live/runtime verification against the test tenant is still pending — I don't currently have the M365 test tenant client secret to run the collector against a real tenant or a full scan. Policy logic is validated via unit tests only for now.