### PR TITLE
docs: document backend migration startup behaviour

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -41,6 +41,38 @@ Automated GCP compliance assessment tool built with FastAPI. This API provides a
    - API Documentation: http://localhost:8000/docs | http://localhost:8000/redoc
    - Root Endpoint: http://localhost:8000/
 
+   ## 🐳 Docker Startup and Database Migrations
+
+When running the backend using the project's Docker configuration, the container starts through `backend-api/entrypoint.sh`.
+
+The startup sequence is:
+
+1. Apply any pending database migrations:
+
+   ```bash
+   uv run alembic upgrade head
+   ```
+
+2. Seed the default administrator account:
+
+   ```bash
+   uv run python -m app.db.init_db
+   ```
+
+3. Start the FastAPI application:
+
+   ```bash
+   uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+   ```
+
+This ensures that the database schema is updated before the backend application starts when using the Docker container.
+
+### Future DevSecOps Improvement
+
+The current implementation executes database migrations during container startup, which is suitable for local development and single-container deployments.
+
+For future production environments using multiple replicas or rolling deployments, database migrations should be enforced as a dedicated deployment or pipeline step before updated application containers receive traffic. This reduces the risk of multiple containers attempting migrations simultaneously and provides a safer deployment process.
+
 ## 📁 Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Updated `backend-api/README.md` to document the current backend container startup sequence.

The documentation now explains that `backend-api/entrypoint.sh`:

1. Runs `uv run alembic upgrade head`
2. Seeds the default administrator account
3. Starts the FastAPI application with Uvicorn

It also records pipeline-level migration enforcement as a future DevSecOps improvement for multi-replica and rolling deployments.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components

- [x] `/backend-api`
- [ ] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation

The T2 2026 backend overview described database migration enforcement as an open gap.

After reviewing the current implementation, I confirmed that the backend container already runs `uv run alembic upgrade head` through `backend-api/entrypoint.sh` before starting Uvicorn.

This change corrects the backend documentation while retaining pipeline-level migration enforcement as a future DevSecOps item for production deployments.

## Testing Done

- [ ] Unit tests pass locally
- [x] Tested manually, verified the documented startup sequence against:
  - `backend-api/Dockerfile`
  - `backend-api/entrypoint.sh`
- [x] No tests required, documentation-only change with no runtime behaviour modified

## Security Considerations

No authentication, secrets, API permissions, or data exposure behaviour was changed.

The documentation only describes existing migration and startup behaviour.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, describe below:

## Rollback Plan

- [x] Revert commit is sufficient
- [ ] Requires additional steps, describe below:

## Checklist

- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [x] Relevant documentation updated
- [ ] CI/CD workflows pass on this branch
- [x] PR is focused on one thing

## Screenshots

Not applicable. This is a documentation-only change.