### PR TITLE
Implement CIS 5.1.4.3 Global Admin local administrator policy

### DIFF
--- a/engine/collectors/entra/devices/device_registration_policy.py
+++ b/engine/collectors/entra/devices/device_registration_policy.py
@@ -38,10 +38,13 @@ class DeviceRegistrationPolicyDataCollector(BaseDataCollector):
         azure_ad_join = policy.get("azureADJoin", {})
         azure_ad_registration = policy.get("azureADRegistration", {})
         local_admin_password = policy.get("localAdminPassword", {})
+        local_admins = azure_ad_join.get("localAdmins",{})
 
         return {
             "device_registration_policy": policy,
             "azure_ad_join_settings": azure_ad_join,
+            "local_admin_settings":local_admins,
+            "global_admins_as_local_admin": local_admins.get("enableGlobalAdmins"),
             "azure_ad_join_allowed": azure_ad_join.get("isAdminConfigurable"),
             "azure_ad_join_allowed_users": azure_ad_join.get("allowedUsers"),
             "azure_ad_join_allowed_groups": azure_ad_join.get("allowedGroups"),

--- a/engine/collectors/graph_client.py
+++ b/engine/collectors/graph_client.py
@@ -35,14 +35,12 @@ class GraphClient:
             scopes=["https://graph.microsoft.com/.default"]
         )
 
-        token = result.get("access_token")
-
-        if not isinstance(token, str):
+        if "access_token" not in result:
             error = result.get("error_description", result.get("error", "Unknown error"))
             raise Exception(f"Failed to acquire token: {error}")
 
-        self._access_token = token
-        return token
+        self._access_token = result["access_token"]
+        return self._access_token
 
     async def _request(
         self,

--- a/engine/collectors/graph_client.py
+++ b/engine/collectors/graph_client.py
@@ -35,12 +35,14 @@ class GraphClient:
             scopes=["https://graph.microsoft.com/.default"]
         )
 
-        if "access_token" not in result:
+        token = result.get("access_token")
+
+        if not isinstance(token, str):
             error = result.get("error_description", result.get("error", "Unknown error"))
             raise Exception(f"Failed to acquire token: {error}")
 
-        self._access_token = result["access_token"]
-        return self._access_token
+        self._access_token = token
+        return token
 
     async def _request(
         self,

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/5.1.4.3_disable_global_admin_local_admin.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/5.1.4.3_disable_global_admin_local_admin.rego
@@ -1,0 +1,51 @@
+# METADATA
+# title: Ensure the GA role is not added as a local administrator during Entra join
+# description: Prevent Global Administrators from automatically receiving local administrator access on Entra-joined devices.
+# related_resources:
+# - ref: https://learn.microsoft.com/en-us/entra/identity/devices/assign-local-admin
+#   description: Microsoft Entra joined device local administrator management
+# custom:
+#   control_id: CIS-5.1.4.3
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: medium
+#   service: EntraID
+#   requires_permissions:
+#   - Policy.Read.DeviceConfiguration
+
+package cis.microsoft_365_foundations.v6_0_0.control_5_1_4_3
+
+import rego.v1
+
+default result := {
+  "compliant": false,
+  "message": "Unable to determine whether Global Administrators are added as local administrators",
+  "details": {},
+}
+
+compliant_value := true if {
+  input.global_admins_as_local_admin == false
+} else := false if {
+  true
+}
+
+msg := "Global Administrators are not automatically added as local administrators" if {
+  input.global_admins_as_local_admin == false
+} else := "Global Administrators are automatically added as local administrators" if {
+  input.global_admins_as_local_admin == true
+} else := "Unable to determine whether Global Administrators are added as local administrators" if {
+  true
+}
+
+result := output if {
+  value := input.global_admins_as_local_admin
+
+  output := {
+    "compliant": compliant_value,
+    "message": msg,
+    "details": {
+      "enable_global_admins": value,
+    },
+  }
+}

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -781,9 +781,9 @@
       "level": "L1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
-      "data_collector_id": "entra.devices.device_management_settings",
-      "policy_file": null,
+      "automation_status": "ready",
+      "data_collector_id": "entra.devices.device_registration_policy",
+      "policy_file": "5.1.4.3_disable_global_admin_local_admin.rego",
       "requires_permissions": ["Policy.Read.All"],
       "notes": null
     },

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -784,7 +784,7 @@
       "automation_status": "ready",
       "data_collector_id": "entra.devices.device_registration_policy",
       "policy_file": "5.1.4.3_disable_global_admin_local_admin.rego",
-      "requires_permissions": ["Policy.Read.All"],
+      "requires_permissions": ["Policy.Read.DeviceConfiguration"],
       "notes": null
     },
     {


### PR DESCRIPTION
## Summary

Implements CIS Microsoft 365 Foundations v6.0.0 Control 5.1.4.3: Ensure the Global Administrator role is not added as a local administrator during Microsoft Entra join.

This PR:
- Updates the Entra device registration policy collector to retrieve `azureADJoin.localAdmins.enableGlobalAdmins`.
- Exposes the value as `global_admins_as_local_admin`.
- Adds a new Rego compliance policy for Control 5.1.4.3.
- Updates `metadata.json` to connect the control to the correct collector and policy file.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [x] Security

## Affected Components

- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation

Control 5.1.4.3 was listed in the CIS benchmark metadata but had no policy file and was not being evaluated during scans.

This implementation enables AutoAudit to assess whether Global Administrators are automatically assigned local administrator privileges on Entra-joined devices.

Planner task: `26T2-ENG-RK-001` — Implement CIS 5.1.4.3 Global Administrator local administrator control.

## Testing Done

- [ ] Unit tests pass locally
- [x] Tested manually — describe how:
  - Validated the Python collector using `python3 -m py_compile`.
  - Validated the Rego policy using `opa check`.
  - Rebuilt all AutoAudit Docker services using the `all` profile.
  - Connected AutoAudit to the Microsoft 365 test tenant.
  - Ran the CIS Microsoft 365 Foundations v6.0.0 compliance scan.
  - Confirmed Control 5.1.4.3 appeared in the scan results.
  - Confirmed the policy returned FAIL when `enableGlobalAdmins` was set to `true`.
  - Confirmed the scan completed with zero runtime errors.
- [ ] No tests required — explain why:

## Security Considerations

This change reads an existing Microsoft Entra device registration policy using Microsoft Graph. It does not modify tenant settings.

No secrets, client credentials, tenant IDs, access tokens, or other sensitive values are included in the code.

The collector requires the existing `Policy.Read.DeviceConfiguration` permission.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe below:

## Rollback Plan

- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

Reverting the collector, metadata, and Rego policy commits will restore the previous behaviour where Control 5.1.4.3 is not evaluated.

## Checklist

- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch
- [x] PR is focused on one thing

## Screenshots
<img width="2813" height="1520" alt="Screenshot From 2026-08-02 20-00-59" src="https://github.com/user-attachments/assets/4798f52b-a263-4228-b1f2-821f28417bb6" />



The test tenant returned:

`Global Administrators are automatically added as local administrators`

Therefore, the control correctly evaluated as FAIL.