### PR TITLE
feat(policy): add AMSI macro scanning control

### DIFF
--- a/engine/policies/essential-eight/asd-essential-eight/v2025/e8_mac_1_3_amsi_scanning.rego
+++ b/engine/policies/essential-eight/asd-essential-eight/v2025/e8_mac_1_3_amsi_scanning.rego
@@ -1,0 +1,77 @@
+# METADATA
+# title: Ensure AMSI scanning is enabled for Office macros
+# description: Ensure Microsoft Office macros are scanned by AMSI before execution.
+# custom:
+#   control_id: E8-MAC-1.3
+#   framework: essential-eight
+#   benchmark: asd-essential-eight
+#   version: v2025
+#   severity: high
+#   service: Intune
+#   maturity_level: ML1
+#   requires_permissions:
+#   - DeviceManagementConfiguration.Read.All
+
+package essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3
+
+import rego.v1
+
+amsi_setting_id := "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope"
+
+default result := {
+  "compliant": false,
+  "message": "AMSI macro scanning setting was not found or is not compliant",
+  "details": {},
+}
+
+# The top-level value only shows that the policy is enabled.
+# The actual AMSI scan scope is stored in:
+# choiceSettingValue.children[0].choiceSettingValue.value
+
+nested_scope_value(setting) := value if {
+  value := setting.settingInstance.choiceSettingValue.children[0].choiceSettingValue.value
+}
+
+is_amsi_setting(setting) if {
+  setting.settingInstance.settingDefinitionId == amsi_setting_id
+}
+
+is_compliant_scope(value) if {
+  endswith(value, "_1")
+}
+
+is_compliant_scope(value) if {
+  endswith(value, "_2")
+}
+
+compliant_setting(setting) if {
+  is_amsi_setting(setting)
+  value := nested_scope_value(setting)
+  is_compliant_scope(value)
+}
+
+compliant if {
+  some policy in input.value
+  some setting in policy.settings
+  compliant_setting(setting)
+}
+
+compliant_value := true if {
+  compliant
+} else := false if {
+  true
+}
+
+message := "AMSI scanning is enabled for Office macros" if {
+  compliant
+} else := "AMSI scanning is not enabled with a compliant scan scope" if {
+  true
+}
+
+result := {
+  "compliant": compliant_value,
+  "message": message,
+  "details": {
+    "setting_id": amsi_setting_id,
+  },
+}

--- a/engine/policies/essential-eight/asd-essential-eight/v2025/e8_mac_1_3_amsi_scanning.rego
+++ b/engine/policies/essential-eight/asd-essential-eight/v2025/e8_mac_1_3_amsi_scanning.rego
@@ -51,7 +51,7 @@ compliant_setting(setting) if {
 }
 
 compliant if {
-  some policy in input.value
+  some policy in input.data.configuration_policies
   some setting in policy.settings
   compliant_setting(setting)
 }

--- a/engine/policies/essential-eight/asd-essential-eight/v2025/metadata.json
+++ b/engine/policies/essential-eight/asd-essential-eight/v2025/metadata.json
@@ -34,9 +34,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -51,9 +49,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -65,12 +61,10 @@
       "maturity_level": "ML1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
-      "data_collector_id": null,
-      "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "automation_status": "ready",
+      "data_collector_id": "entra.devices.configuration_policies",
+      "policy_file": "e8_mac_1_3_amsi_scanning.rego",
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -85,9 +79,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -102,9 +94,7 @@
       "automation_status": "ready",
       "data_collector_id": "entra.devices.asr_rules",
       "policy_file": "e8_mac_2_1_win32_api_block.rego",
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Fully automatable."
     },
     {
@@ -119,9 +109,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -151,9 +139,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {
@@ -168,9 +154,7 @@
       "automation_status": "not_started",
       "data_collector_id": null,
       "policy_file": null,
-      "requires_permissions": [
-        "DeviceManagementConfiguration.Read.All"
-      ],
+      "requires_permissions": ["DeviceManagementConfiguration.Read.All"],
       "notes": "Partial automation."
     },
     {

--- a/engine/tests/fixtures/entra_devices_configuration_policies_20260727_103136.json
+++ b/engine/tests/fixtures/entra_devices_configuration_policies_20260727_103136.json
@@ -1,0 +1,177 @@
+{
+  "collector_id": "entra.devices.configuration_policies",
+  "timestamp": "2026-07-27T10:31:36.210031",
+  "elapsed_seconds": 2.689,
+  "data": {
+    "configuration_policies": [
+      {
+        "createdDateTime": "2026-07-26T03:46:27.1475394Z",
+        "creationSource": null,
+        "description": "For E8-MAC-1.1, 1.2 and 1.3",
+        "lastModifiedDateTime": "2026-07-26T03:46:27.1475394Z",
+        "name": "E8_MACRO",
+        "platforms": "windows10",
+        "priorityMetaData": null,
+        "roleScopeTagIds": ["0"],
+        "settingCount": 7,
+        "technologies": "mdm",
+        "id": "3e6c6222-4466-401a-8b8d-5c7058c8d432",
+        "templateReference": {
+          "templateId": "",
+          "templateFamily": "none",
+          "templateDisplayName": null,
+          "templateDisplayVersion": null
+        },
+        "settings": [
+          {
+            "id": "0",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet_1",
+                "children": []
+              }
+            }
+          },
+          {
+            "id": "1",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_vbawarningspolicy",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_vbawarningspolicy_1",
+                "children": [
+                  {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                    "settingDefinitionId": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty4",
+                    "settingInstanceTemplateReference": null,
+                    "auditRuleInformation": null,
+                    "choiceSettingValue": {
+                      "settingValueTemplateReference": null,
+                      "value": "user_vendor_msft_policy_config_excel16v2~policy~l_microsoftofficeexcel~l_exceloptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty4_2",
+                      "children": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "2",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope_1",
+                "children": [
+                  {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                    "settingDefinitionId": "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope_l_macroruntimescanscopeenum",
+                    "settingInstanceTemplateReference": null,
+                    "auditRuleInformation": null,
+                    "choiceSettingValue": {
+                      "settingValueTemplateReference": null,
+                      "value": "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope_l_macroruntimescanscopeenum_2",
+                      "children": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "3",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet_1",
+                "children": []
+              }
+            }
+          },
+          {
+            "id": "4",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_vbawarningspolicy",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_vbawarningspolicy_1",
+                "children": [
+                  {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                    "settingDefinitionId": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty3",
+                    "settingInstanceTemplateReference": null,
+                    "auditRuleInformation": null,
+                    "choiceSettingValue": {
+                      "settingValueTemplateReference": null,
+                      "value": "user_vendor_msft_policy_config_ppt16v2~policy~l_microsoftofficepowerpoint~l_powerpointoptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty3_2",
+                      "children": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "id": "5",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_blockmacroexecutionfrominternet_1",
+                "children": []
+              }
+            }
+          },
+          {
+            "id": "6",
+            "settingInstance": {
+              "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+              "settingDefinitionId": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_vbawarningspolicy",
+              "settingInstanceTemplateReference": null,
+              "auditRuleInformation": null,
+              "choiceSettingValue": {
+                "settingValueTemplateReference": null,
+                "value": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_vbawarningspolicy_1",
+                "children": [
+                  {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                    "settingDefinitionId": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty19",
+                    "settingInstanceTemplateReference": null,
+                    "auditRuleInformation": null,
+                    "choiceSettingValue": {
+                      "settingValueTemplateReference": null,
+                      "value": "user_vendor_msft_policy_config_word16v2~policy~l_microsoftofficeword~l_wordoptions~l_security~l_trustcenter_l_vbawarningspolicy_l_empty19_2",
+                      "children": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "total_configuration_policies": 1
+  }
+}

--- a/engine/tests/test_e8_mac_1_3_amsi_scanning.rego
+++ b/engine/tests/test_e8_mac_1_3_amsi_scanning.rego
@@ -1,0 +1,102 @@
+package essential_eight.asd_essential_eight.v2025.test_e8_mac_1_3
+
+import rego.v1
+
+amsi_setting_id := "user_vendor_msft_policy_config_office16v2~policy~l_microsoftofficesystem~l_securitysettings_l_macroruntimescanscope"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build minimal Settings Catalog data for the AMSI setting
+# ---------------------------------------------------------------------------
+
+amsi_setting(scope_value) := {
+    "settingInstance": {
+        "settingDefinitionId": amsi_setting_id,
+        "choiceSettingValue": {
+            "value": "enabled_1",
+            "children": [
+                {
+                    "choiceSettingValue": {
+                        "value": scope_value,
+                    },
+                },
+            ],
+        },
+    },
+}
+
+configuration_policy(settings) := {
+    "id": "policy-001",
+    "name": "Microsoft Office macro security policy",
+    "settings": settings,
+}
+
+
+# ---------------------------------------------------------------------------
+# Test: compliant — AMSI scanning is enabled for low-trust documents
+# ---------------------------------------------------------------------------
+
+test_compliant_scope_1 if {
+    result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
+        "value": [
+            configuration_policy([
+                amsi_setting("amsi_scan_scope_1"),
+            ]),
+        ],
+    }
+
+    result.compliant == true
+    contains(result.message, "AMSI scanning is enabled")
+}
+
+
+# ---------------------------------------------------------------------------
+# Test: compliant — AMSI scanning is enabled for all documents
+# ---------------------------------------------------------------------------
+
+test_compliant_scope_2 if {
+    result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
+        "value": [
+            configuration_policy([
+                amsi_setting("amsi_scan_scope_2"),
+            ]),
+        ],
+    }
+
+    result.compliant == true
+    contains(result.message, "AMSI scanning is enabled")
+}
+
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — nested scope has an unsupported value
+# ---------------------------------------------------------------------------
+
+test_non_compliant_invalid_scope if {
+    result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
+        "value": [
+            configuration_policy([
+                amsi_setting("amsi_scan_scope_0"),
+            ]),
+        ],
+    }
+
+    result.compliant == false
+    contains(result.message, "not enabled")
+}
+
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — AMSI setting is missing
+# ---------------------------------------------------------------------------
+
+test_non_compliant_missing_setting if {
+    result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
+        "value": [
+            configuration_policy([]),
+        ],
+    }
+
+    result.compliant == false
+    contains(result.message, "not enabled")
+}

--- a/engine/tests/test_e8_mac_1_3_amsi_scanning.rego
+++ b/engine/tests/test_e8_mac_1_3_amsi_scanning.rego
@@ -13,7 +13,7 @@ amsi_setting(scope_value) := {
     "settingInstance": {
         "settingDefinitionId": amsi_setting_id,
         "choiceSettingValue": {
-            "value": "enabled_1",
+            "value": sprintf("%s_1", [amsi_setting_id]),
             "children": [
                 {
                     "choiceSettingValue": {
@@ -38,11 +38,13 @@ configuration_policy(settings) := {
 
 test_compliant_scope_1 if {
     result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
-        "value": [
-            configuration_policy([
-                amsi_setting("amsi_scan_scope_1"),
-            ]),
-        ],
+        "data": {
+            "configuration_policies": [
+                configuration_policy([
+                    amsi_setting("amsi_scan_scope_1"),
+                ]),
+            ],
+        },
     }
 
     result.compliant == true
@@ -56,11 +58,13 @@ test_compliant_scope_1 if {
 
 test_compliant_scope_2 if {
     result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
-        "value": [
-            configuration_policy([
-                amsi_setting("amsi_scan_scope_2"),
-            ]),
-        ],
+        "data": {
+            "configuration_policies": [
+                configuration_policy([
+                    amsi_setting("amsi_scan_scope_2"),
+                ]),
+            ],
+        },
     }
 
     result.compliant == true
@@ -74,11 +78,13 @@ test_compliant_scope_2 if {
 
 test_non_compliant_invalid_scope if {
     result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
-        "value": [
-            configuration_policy([
-                amsi_setting("amsi_scan_scope_0"),
-            ]),
-        ],
+        "data": {
+            "configuration_policies": [
+                configuration_policy([
+                    amsi_setting("amsi_scan_scope_0"),
+                ]),
+            ],
+        },
     }
 
     result.compliant == false
@@ -92,9 +98,11 @@ test_non_compliant_invalid_scope if {
 
 test_non_compliant_missing_setting if {
     result := data.essential_eight.asd_essential_eight.v2025.control_e8_mac_1_3.result with input as {
-        "value": [
-            configuration_policy([]),
-        ],
+        "data": {
+            "configuration_policies": [
+                configuration_policy([]),
+            ],
+        },
     }
 
     result.compliant == false


### PR DESCRIPTION
## Summary

-Added a Rego policy for E8-MAC-1.3 to check whether AMSI scanning is enabled for Microsoft Office macros
-Updated the policy to use the real collector structure: data.configuration_policies
-Read the AMSI scan scope from the nested Settings Catalog value
-Treat values ending in _1 and _2 as compliant
-Added unit tests for compliant, invalid, and missing setting cases
-Added the real collector JSON fixture for testing
-Updated metadata for E8-MAC-1.3

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [x] Security

## Affected Components

- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Changes Made

- Added `e8_mac_1_3_amsi_scanning.rego`
- Added `test_e8_mac_1_3_amsi_scanning.rego`
- Added the real Settings Catalog collector fixture
- Added support for the confirmed AMSI setting ID
- Added nested value checking through:
  `choiceSettingValue.children[0].choiceSettingValue.value`
- Added four OPA unit tests:
  - `_1` scope is compliant
  - `_2` scope is compliant
  - invalid scope is non-compliant
  - missing setting is non-compliant
  - Confirmed the AMSI setting ID from the real collector output
  - Confirmed the nested scan scope path: choiceSettingValue.children[0].choiceSettingValue.value
  - Updated the top-level input path to: data.configuration_policies
  - Updated the E8-MAC-1.3 metadata and policy file wiring

## Testing
I ran the OPA tests locally:

D:\Tools\OPA\opa.exe test `
  "D:\AutoAudit\engine\policies\essential-eight\asd-essential-eight\v2025\e8_mac_1_3_amsi_scanning.rego" `
  "D:\AutoAudit\engine\tests\test_e8_mac_1_3_amsi_scanning.rego" `
  --fail-on-empty `
  -v

<img width="1912" height="1080" alt="6 1" src="https://github.com/user-attachments/assets/50184021-8dc2-4719-8d37-f5fe805c7a0c" />
Result:

PASS: 4/4

The tests cover:

_1 scope → compliant
_2 scope → compliant
invalid scope → non-compliant
missing AMSI setting → non-compliant


## Notes

The real collector JSON fixture is now available. I updated the policy and test input structure to match the actual collector output. The AMSI setting ID and nested scan scope path were also confirmed using the real JSON data.

## Checklist
- [x] Policy file added
- [x] Unit tests added
- [x] All four OPA tests pass locally
- [x] No unrelated backend dependency changes included
- [x] Real collector fixture confirmed
- [x] Metadata updated to ready
