### PR TITLE
Implement CIS 1.3.7 - Third-party storage services restriction

### DIFF
--- a/engine/collectors/entra/applications/third_party_storage_services.py
+++ b/engine/collectors/entra/applications/third_party_storage_services.py
@@ -34,19 +34,20 @@ class ThirdPartyStorageServicesDataCollector(BaseDataCollector):
             - service_principal_exists: Whether the SP has been created in the tenant
             - account_enabled: The SP's accountEnabled value (None if not found)
             - service_principal: Raw service principal object, if found
+
+        Raises:
+            Any exception from the Graph API call is propagated so the worker
+            pipeline can retry or mark this control as an evaluation error,
+            rather than silently reporting a false non-compliance result.
         """
-        collector_error: str | None = None
         service_principal: dict[str, Any] | None = None
 
-        try:
-            resp = await client.get(
-                f"/servicePrincipals?$filter=appId eq '{THIRD_PARTY_STORAGE_APP_ID}'"
-            )
-            results = resp.get("value") if isinstance(resp, dict) else None
-            if isinstance(results, list) and results:
-                service_principal = results[0]
-        except Exception as exc:
-            collector_error = str(exc)
+        resp = await client.get(
+            f"/servicePrincipals?$filter=appId eq '{THIRD_PARTY_STORAGE_APP_ID}'"
+        )
+        results = resp.get("value") if isinstance(resp, dict) else None
+        if isinstance(results, list) and results:
+            service_principal = results[0]
 
         account_enabled = (
             service_principal.get("accountEnabled")
@@ -58,5 +59,5 @@ class ThirdPartyStorageServicesDataCollector(BaseDataCollector):
             "service_principal_exists": service_principal is not None,
             "account_enabled": account_enabled,
             "service_principal": service_principal,
-            "collector_error": collector_error,
         }
+    

--- a/engine/collectors/entra/applications/third_party_storage_services.py
+++ b/engine/collectors/entra/applications/third_party_storage_services.py
@@ -1,0 +1,62 @@
+"""Third-party storage services collector.
+
+CIS Microsoft 365 Foundations Benchmark Controls:
+    v6.0.0: 1.3.7
+
+Connection Method: Microsoft Graph API
+Required Scopes: Application.Read.All
+Graph Endpoint: /servicePrincipals (v1.0)
+"""
+
+from typing import Any
+
+from collectors.base import BaseDataCollector
+from collectors.graph_client import GraphClient
+
+# Well-known appId for the "Third Party Storage Services" service principal
+# referenced by CIS control 1.3.7 (Microsoft 365 on the web).
+THIRD_PARTY_STORAGE_APP_ID = "c1f33bc0-bdb4-4248-ba9b-096807ddb43e"
+
+
+class ThirdPartyStorageServicesDataCollector(BaseDataCollector):
+    """Collects the Third Party Storage Services service principal state.
+
+    This collector retrieves the Entra ID service principal that governs
+    whether users can open files stored in third-party storage providers
+    (e.g. Dropbox) from Microsoft 365 on the web, to verify it is disabled.
+    """
+
+    async def collect(self, client: GraphClient) -> dict[str, Any]:
+        """Collect third-party storage service principal data.
+
+        Returns:
+            Dict containing:
+            - service_principal_exists: Whether the SP has been created in the tenant
+            - account_enabled: The SP's accountEnabled value (None if not found)
+            - service_principal: Raw service principal object, if found
+        """
+        collector_error: str | None = None
+        service_principal: dict[str, Any] | None = None
+
+        try:
+            resp = await client.get(
+                f"/servicePrincipals?$filter=appId eq '{THIRD_PARTY_STORAGE_APP_ID}'"
+            )
+            results = resp.get("value") if isinstance(resp, dict) else None
+            if isinstance(results, list) and results:
+                service_principal = results[0]
+        except Exception as exc:
+            collector_error = str(exc)
+
+        account_enabled = (
+            service_principal.get("accountEnabled")
+            if isinstance(service_principal, dict)
+            else None
+        )
+
+        return {
+            "service_principal_exists": service_principal is not None,
+            "account_enabled": account_enabled,
+            "service_principal": service_principal,
+            "collector_error": collector_error,
+        }

--- a/engine/collectors/registry.py
+++ b/engine/collectors/registry.py
@@ -8,6 +8,9 @@ from collectors.entra.applications.apps_and_services_settings import (
 )
 from collectors.entra.applications.forms_settings import FormsSettingsDataCollector
 
+from collectors.entra.applications.third_party_storage_services import (
+    ThirdPartyStorageServicesDataCollector,
+)
 # Authentication
 from collectors.entra.authentication.authentication_methods import (
     AuthenticationMethodsDataCollector,
@@ -144,6 +147,7 @@ DATA_COLLECTORS: dict[str, type[BaseDataCollector]] = {
     # Applications
     "entra.applications.apps_and_services_settings": AppsAndServicesSettingsDataCollector,
     "entra.applications.forms_settings": FormsSettingsDataCollector,
+    "entra.applications.third_party_storage_services": ThirdPartyStorageServicesDataCollector,
     # Authentication
     "entra.authentication.authentication_methods": AuthenticationMethodsDataCollector,
     "entra.authentication.mfa_fatigue_protection": MfaFatigueProtectionDataCollector,

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.7_third_party_storage_services.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.3.7_third_party_storage_services.rego
@@ -1,0 +1,70 @@
+# METADATA
+# title: Ensure 'third-party storage services' are restricted in 'Microsoft 365 on the web'
+# description: |
+#   Third-party storage services (Dropbox, Google Drive, Box, etc.) can be
+#   enabled for users in Microsoft 365 on the web, allowing them to store and
+#   share documents outside organizational control alongside OneDrive and
+#   team sites. This increases the risk of data breaches and makes it
+#   difficult to maintain data privacy and security. Restrict the "Third
+#   Party Storage Services" service principal in Entra ID to prevent this.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-1.3.7
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: medium
+#   service: EntraID
+#   requires_permissions:
+#   - Application.Read.All
+
+package cis.microsoft_365_foundations.v6_0_0.control_1_3_7
+
+default result := {"compliant": false, "message": "Evaluation failed"}
+
+result := output if {
+    exists := input.service_principal_exists
+    enabled := input.account_enabled
+    is_compliant := is_restricted(exists, enabled)
+
+    output := {
+        "compliant": is_compliant,
+        "message": generate_message(exists, enabled),
+        "affected_resources": affected_resources(exists, enabled),
+        "details": {
+            "service_principal_exists": exists,
+            "account_enabled": enabled,
+            "app_id": "c1f33bc0-bdb4-4248-ba9b-096807ddb43e"
+        }
+    }
+}
+
+# Compliant only when the service principal has been created AND disabled
+is_restricted(exists, enabled) := true if {
+    exists == true
+    enabled == false
+} else := false
+
+generate_message(exists, enabled) := msg if {
+    exists == true
+    enabled == false
+    msg := "The 'Third Party Storage Services' service principal is disabled; third-party storage is restricted."
+}
+
+generate_message(exists, _) := msg if {
+    exists == false
+    msg := "The 'Third Party Storage Services' service principal has not been created; third-party storage remains available by default."
+}
+
+generate_message(exists, enabled) := msg if {
+    exists == true
+    enabled == true
+    msg := "The 'Third Party Storage Services' service principal exists but is still enabled (accountEnabled: true)."
+}
+
+affected_resources(exists, enabled) := [] if {
+    exists == true
+    enabled == false
+} else := ["Third Party Storage Services (appId: c1f33bc0-bdb4-4248-ba9b-096807ddb43e)"]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -192,15 +192,15 @@
       "title": "Ensure 'third-party storage services' are restricted in 'Microsoft 365 on the web'",
       "description": "Restrict third-party storage providers in Office web apps.",
       "severity": "medium",
-      "service": "Exchange",
+      "service": "EntraID",
       "level": "L2",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
-      "data_collector_id": "exchange.organization.owa_mailbox_policy",
-      "policy_file": null,
-      "requires_permissions": ["Exchange.Manage"],
-      "notes": "Collector exists but control logic not defined"
+      "automation_status": "ready",
+      "data_collector_id": "entra.applications.third_party_storage_services",
+      "policy_file": "1.3.7_third_party_storage_services.rego",
+      "requires_permissions": ["Application.Read.All"],
+      "notes": null
     },
     {
       "control_id": "1.3.8",

--- a/engine/tests/test_1_3_7_third_party_storage_services.rego
+++ b/engine/tests/test_1_3_7_third_party_storage_services.rego
@@ -1,0 +1,83 @@
+package cis.microsoft_365_foundations.v6_0_0.test_1_3_7
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Test: compliant — service principal exists and is disabled
+# ---------------------------------------------------------------------------
+
+test_compliant_service_principal_disabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_7.result with input as {
+        "service_principal_exists": true,
+        "account_enabled": false,
+        "service_principal": {
+            "id": "sp-001",
+            "appId": "c1f33bc0-bdb4-4248-ba9b-096807ddb43e",
+            "accountEnabled": false,
+        },
+        "collector_error": null,
+    }
+    result.compliant == true
+    result.details.service_principal_exists == true
+    result.details.account_enabled == false
+    count(result.affected_resources) == 0
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — service principal has never been created (default state)
+# ---------------------------------------------------------------------------
+
+test_non_compliant_service_principal_not_created if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_7.result with input as {
+        "service_principal_exists": false,
+        "account_enabled": null,
+        "service_principal": null,
+        "collector_error": null,
+    }
+    result.compliant == false
+    result.details.service_principal_exists == false
+    count(result.affected_resources) == 1
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-compliant — service principal exists but is still enabled
+# ---------------------------------------------------------------------------
+
+test_non_compliant_service_principal_enabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_7.result with input as {
+        "service_principal_exists": true,
+        "account_enabled": true,
+        "service_principal": {
+            "id": "sp-001",
+            "appId": "c1f33bc0-bdb4-4248-ba9b-096807ddb43e",
+            "accountEnabled": true,
+        },
+        "collector_error": null,
+    }
+    result.compliant == false
+    result.details.account_enabled == true
+    count(result.affected_resources) == 1
+}
+
+# ---------------------------------------------------------------------------
+# Test: details include correct evidence fields
+# ---------------------------------------------------------------------------
+
+test_result_details_structure if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_3_7.result with input as {
+        "service_principal_exists": true,
+        "account_enabled": false,
+        "service_principal": {
+            "id": "sp-001",
+            "appId": "c1f33bc0-bdb4-4248-ba9b-096807ddb43e",
+            "accountEnabled": false,
+        },
+        "collector_error": null,
+    }
+    _ = result.compliant
+    _ = result.message
+    _ = result.affected_resources
+    _ = result.details.service_principal_exists
+    _ = result.details.account_enabled
+    _ = result.details.app_id
+}


### PR DESCRIPTION
Implements CIS control 1.3.7 (restrict third-party storage services in Microsoft 365 on the web).

While working on this, I found that metadata.json had 1.3.7 pointing to the wrong collector — it was set to the same collector used by control 6.5.3, but 1.3.7 actually needs to check something different (a service principal setting in Entra ID, not an Exchange setting). Confirmed this against the official CIS benchmark documentation.

What this PR adds:
- A new collector for the Entra ID service principal check
- A Rego policy for the control, plus unit tests
- Registered the new collector
- Updated metadata.json with the correct collector, permissions, and status

Tested and confirmed working:
- Unit tests pass
- Ran the full structural test suite, all passing
- Ran a live scan against the test tenant and confirmed the control evaluates correctly

## Summary
Implements control 1.3.7, including fixing an incorrect collector mapping found in metadata.json.

## Type of Change
- [x] New feature
- [x] Bug fix