### PR TITLE
ci: Add top-level permissions block to workflows missing explicit permissions

### DIFF
--- a/.github/workflows/ci.backend-api.yml
+++ b/.github/workflows/ci.backend-api.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '32 23 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Security Analysis on (${{ matrix.language }})

--- a/.github/workflows/ci.engine.yml
+++ b/.github/workflows/ci.engine.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '32 23 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Security Analysis on (${{ matrix.language }})

--- a/.github/workflows/ci.frontend.yml
+++ b/.github/workflows/ci.frontend.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '32 23 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Security Analysis on (${{ matrix.language }})

--- a/.github/workflows/ci.security.yml
+++ b/.github/workflows/ci.security.yml
@@ -16,6 +16,9 @@ on:
   schedule:
     - cron: '32 23 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Security Analysis on (${{ matrix.language }})

--- a/.github/workflows/ci.validate-alerts.yml
+++ b/.github/workflows/ci.validate-alerts.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'infrastructure/monitoring/alerts/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate_alerts:
     runs-on: ubuntu-latest

--- a/.github/workflows/ops.collector.yml
+++ b/.github/workflows/ops.collector.yml
@@ -3,6 +3,9 @@ name: Run Collector
 on:
   push:
     branches: [engine-development]
+
+permissions:
+  contents: read
     
 jobs:
   run-collector:

--- a/.github/workflows/ops.short-test.yml
+++ b/.github/workflows/ops.short-test.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - ".github/workflows/short-test.yml"  # Only trigger when this file changes
 
+permissions:
+  contents: read
+
 jobs:
   quick-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of Workstream 1 (CI architecture and workflow supply chain). Audited all 15 workflow files in .github/workflows and found 7 with no top-level permissions: block, meaning some jobs (e.g. run-lint, test, build-and-test) were inheriting default token permissions rather than an explicit least-privilege scope. This PR adds permissions: contents: read at the top level of each affected workflow as a safe baseline; job-level permission overrides (e.g. security-events: write in analyze) are unaffected.

Before: 7 of 15 workflows had no explicit permissions block
After: 15 of 15 workflows now have an explicit top-level or job-level permissions block

Next: pinning third-party actions to commit SHAs (separate PR).