### PR TITLE
Improve PR size warning guidance

### DIFF
--- a/.github/workflows/pr.size-warning.yml
+++ b/.github/workflows/pr.size-warning.yml
@@ -30,14 +30,52 @@ jobs:
             // without blocking normal development work.
             const fileWarn = 30;
             const lineWarn = 500;
+            const docsPath = "docs/DevSecOps/pr-size-warning.md";
+
+            const summary = core.summary
+              .addHeading("PR size check")
+              .addTable([
+                [
+                  { data: "Metric", header: true },
+                  { data: "PR total", header: true },
+                  { data: "Warning threshold", header: true }
+                ],
+                ["Files changed", String(files), `More than ${fileWarn}`],
+                ["Lines changed", String(total), `More than ${lineWarn}`],
+                ["Additions", String(additions), "-"],
+                ["Deletions", String(deletions), "-"]
+              ]);
 
             if (files > fileWarn || total > lineWarn) {
               core.warning(
                 `PR is large: ${files} files, ${additions} additions, ${deletions} deletions (${total} total). ` +
-                `Consider splitting it into smaller PRs where possible.`
+                `Open this workflow run's job summary for next steps. Split unrelated changes where possible; ` +
+                `otherwise explain why the PR must remain large and identify size increases from generated files, ` +
+                `lock files, migrations, or formatting-only changes. See ${docsPath}. This warning does not block the PR.`
               );
+
+              summary
+                .addRaw(
+                  "**Warning only:** This PR exceeds a size threshold. The check does not block the PR.",
+                  true
+                )
+                .addHeading("Recommended next steps", 2)
+                .addList([
+                  "Split unrelated changes into smaller PRs where possible.",
+                  "Avoid combining frontend, backend, engine, documentation, and workflow changes unless they are directly related.",
+                  "If the PR cannot be split, explain in the PR description why it must remain large.",
+                  "Mention generated files, lock file updates, migrations, or formatting-only changes if they increased the PR size."
+                ])
+                .addRaw(`See \`${docsPath}\` for the contributor guide.`, true);
             } else {
               core.info(
                 `PR size OK: ${files} files, ${additions} additions, ${deletions} deletions (${total} total).`
               );
+
+              summary.addRaw(
+                `This PR is within the warning thresholds. See \`${docsPath}\` for guidance.`,
+                true
+              );
             }
+
+            await summary.write();

--- a/docs/DevSecOps/pr-size-warning.md
+++ b/docs/DevSecOps/pr-size-warning.md
@@ -1,0 +1,28 @@
+# PR Size Warning
+
+The PR size warning helps contributors and reviewers identify pull requests that may be difficult to review safely. It runs when a pull request targeting `main` is opened, updated, or reopened.
+
+## When the warning appears
+
+The warning appears when a pull request changes more than 30 files or has more than 500 changed lines in total (additions plus deletions). Open the **PR Size Warning** workflow run from the pull request's **Checks** tab to see the warning and job summary.
+
+This check is warning-only. It does not fail the workflow, block the pull request, or prevent merging.
+
+## What to do
+
+If the warning appears:
+
+- Split unrelated changes into smaller pull requests where possible.
+- Avoid combining frontend, backend, engine, documentation, and workflow changes unless they are directly related.
+- If the pull request cannot be split, explain in its description why it must remain large.
+- Mention generated files, lock file updates, migrations, or formatting-only changes if they increased the reported size.
+
+## When a large PR is acceptable
+
+A large pull request may be reasonable when its changes are tightly related and separating them would make the implementation incomplete or harder to understand. Examples include coordinated cross-component changes, migrations, generated output that must accompany a source change, and repository-wide formatting or dependency updates.
+
+When this happens, describe the relationship between the changes, identify any mechanical or generated changes, and suggest a useful review order.
+
+## Why smaller PRs help
+
+Smaller, focused pull requests reduce reviewer fatigue, make defects and security issues easier to spot, and allow feedback to arrive sooner. They are also easier to test, revert, and understand later from the project history.


### PR DESCRIPTION
## Summary

Improves the existing PR size warning workflow so contributors receive clearer guidance when a pull request exceeds the configured size thresholds.

This update keeps the workflow warning-only, but adds clearer next steps, a GitHub Actions job summary, and contributor documentation explaining how to respond to the warning.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Documentation
- [x] CI/CD / infrastructure
- [ ] Security

## Testing

Tested using a sample pull request in my fork that exceeded the configured line threshold. The workflow ran successfully, displayed the PR size warning, and showed the updated contributor guidance without blocking the PR.