### PR TITLE
feat(api): add security response headers

### DIFF
--- a/backend-api/app/core/middleware.py
+++ b/backend-api/app/core/middleware.py
@@ -1,24 +1,49 @@
-import logging
+﻿import logging
 import time
+
 from starlette.middleware.base import BaseHTTPMiddleware
 
+
 logger = logging.getLogger("api")
+
+
+SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Content-Security-Policy": "frame-ancestors 'none'",
+    "Referrer-Policy": "no-referrer",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+}
+
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         start_time = time.time()
 
-        # Process request
         response = await call_next(request)
 
         duration = round(time.time() - start_time, 3)
 
-        # Log only metadata 
-        logger.info({
-            "method": request.method,
-            "path": request.url.path,
-            "status_code": response.status_code,
-            "duration": duration
-        })
+        logger.info(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration": duration,
+            }
+        )
+
+        return response
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add security-related headers to every API response."""
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+
+        for header_name, header_value in SECURITY_HEADERS.items():
+            if header_name not in response.headers:
+                response.headers[header_name] = header_value
 
         return response

--- a/backend-api/app/main.py
+++ b/backend-api/app/main.py
@@ -1,9 +1,9 @@
-from fastapi import FastAPI
+﻿from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.logging import setup_logging
 from app.api.v1.router import api_router
 from app.core.config import get_settings
-from app.core.middleware import RequestLoggingMiddleware
+from app.core.middleware import RequestLoggingMiddleware, SecurityHeadersMiddleware
 from app.core.errors import not_found_handler, NotFound
 settings = get_settings()
 
@@ -15,6 +15,7 @@ def create_app() -> FastAPI:
     # RequestLoggingMiddleware must be added before CORSMiddleware
     # (middleware executes in reverse order - last added runs first)
     app.add_middleware(RequestLoggingMiddleware)
+    app.add_middleware(SecurityHeadersMiddleware)
 
     # Allow frontend (localhost:3000 and others) to call the API during development.
     # CORS must be added last so it runs first and wraps all responses including errors.
@@ -43,3 +44,4 @@ def create_app() -> FastAPI:
     return app
 
 app = create_app()
+

--- a/backend-api/tests/test_security_headers.py
+++ b/backend-api/tests/test_security_headers.py
@@ -1,0 +1,47 @@
+﻿import unittest
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+EXPECTED_HEADERS = {
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "content-security-policy": "frame-ancestors 'none'",
+    "referrer-policy": "no-referrer",
+    "permissions-policy": "camera=(), microphone=(), geolocation=()",
+}
+
+
+class TestSecurityHeaders(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.client.close()
+
+    def check_security_headers(self, response):
+        for header_name, expected_value in EXPECTED_HEADERS.items():
+            self.assertEqual(
+                response.headers.get(header_name),
+                expected_value,
+                f"Missing or incorrect header: {header_name}",
+            )
+
+    def test_security_headers_on_success_response(self):
+        response = self.client.get("/liveness")
+
+        self.assertEqual(response.status_code, 200)
+        self.check_security_headers(response)
+
+    def test_security_headers_on_not_found_response(self):
+        response = self.client.get("/does-not-exist")
+
+        self.assertEqual(response.status_code, 404)
+        self.check_security_headers(response)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

Adds reusable security response headers to the AutoAudit FastAPI backend.

 Changes

- Added `SecurityHeadersMiddleware`
- Added `X-Content-Type-Options: nosniff`
- Added `X-Frame-Options: DENY`
- Added `Content-Security-Policy`
- Added `Referrer-Policy`
- Added `Permissions-Policy`
- Registered the middleware globally
- Added automated tests for successful and 404 responses

 Testing

Manual testing completed successfully:

- `/liveness` returned `200 OK` with all security headers
- A non-existent route returned `404 Not Found` with all security headers

Automated tests were run using:

`uv run python -m unittest discover -s tests -p "test_*.py" -v`

Result:

- 2 tests passed successfully

Purpose

This contribution adds a consistent security baseline to backend HTTP responses and improves protection against common browser-based security risks.