### PR TITLE
Add logging to silent backend exception handlers (BE-JN-001)

### DIFF
--- a/backend-api/app/api/v1/auth.py
+++ b/backend-api/app/api/v1/auth.py
@@ -1,4 +1,5 @@
 import secrets
+import logging
 from urllib.parse import urlencode
 
 import httpx
@@ -12,6 +13,8 @@ from app.core.users import auth_backend, fastapi_users, get_jwt_strategy, get_us
 from app.schemas.user import UserRead, UserCreate, UserRegister, UserUpdate
 from app.core.auth import get_current_user
 from app.models.user import User
+
+logger = logging.getLogger("api")
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
@@ -223,6 +226,7 @@ async def google_callback(
         token = await client.get_access_token(code, redirect_uri=_google_redirect_uri())
         google_access_token = token["access_token"]
     except Exception:
+        logger.exception("Google OAuth token exchange failed")
         return RedirectResponse(
             _frontend_google_callback_url(
                 {
@@ -243,6 +247,7 @@ async def google_callback(
         resp.raise_for_status()
         profile = resp.json()
     except Exception:
+        logger.exception("Google OAuth userinfo fetch failed")
         return RedirectResponse(
             _frontend_google_callback_url(
                 {
@@ -293,6 +298,7 @@ async def google_callback(
             is_verified_by_default=True,
         )
     except Exception:
+        logger.exception("Google OAuth account linking failed")
         return RedirectResponse(
             _frontend_google_callback_url(
                 {

--- a/backend-api/app/api/v1/evidence.py
+++ b/backend-api/app/api/v1/evidence.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import json
 
 from fastapi import APIRouter, Depends, UploadFile, File, Form
@@ -8,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # Ensure the monorepo /security package is importable both locally and inside Docker
 import sys
 from pathlib import Path
+
+logger = logging.getLogger("api")
 
 
 def _find_security_dir() -> Path | None:
@@ -116,6 +119,7 @@ async def scan(
             text_hash = hashlib.sha256(extracted_text.encode("utf-8", errors="ignore")).hexdigest()
     except Exception:
         # Do not block scan if validator pre-pass fails.
+        logger.warning("Evidence validator pre-pass failed; continuing without validator", exc_info=True)
         extracted_text = ""
         validator_payload = None
         text_hash = None
@@ -175,10 +179,11 @@ async def scan(
             db.add(record)
             await db.commit()
     except Exception:
+        logger.warning("Failed to persist evidence validation; rolling back", exc_info=True)
         try:
             await db.rollback()
         except Exception:
-            pass
+            logger.warning("Rollback after evidence validation failure also failed", exc_info=True)
 
     return scan_result
 

--- a/backend-api/app/services/scan_readiness.py
+++ b/backend-api/app/services/scan_readiness.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 from dataclasses import dataclass
 import httpx
+import logging
 from app.services.m365_graph import (
     M365ConnectionError,
     acquire_graph_access_token,
     validate_m365_connection,
 )
+
+logger = logging.getLogger("api")
 
 # These permissions are critical for the current M365 benchmarks, so we always probe them and treat failures as critical.
 CRITICAL_BASELINE_PERMISSIONS = {
@@ -197,6 +200,7 @@ async def evaluate_scan_readiness(
                     headers={"Authorization": f"Bearer {access_token}"},
                 )
             except Exception:
+                logger.warning("Readiness probe request failed for permission %s; marking unverified", permission, exc_info=True)
                 unverified_permissions.add(permission)
                 checks.append(
                     ReadinessCheck(


### PR DESCRIPTION
## Summary
Adds logging to seven backend exception handlers that previously recovered from failures without leaving any trace. Each handler now records the failure before recovering, so silent failures become diagnosable. Recovery behaviour is unchanged.

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [x] `/backend-api`
- [ ] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
Several broad exception handlers in the backend recovered from failures silently, with no log output, which made those failures impossible to diagnose. This adds visibility without changing how the code recovers. Task: BE-JN-001.

Changes:
- auth.py: the three Google OAuth callback failures (token exchange, userinfo fetch, account linking), logged at exception level.
- evidence.py: the validator pre-pass and the validator-persist rollback, logged at warning level.
- scan_readiness.py: the permission probe failure, logged at warning level.

## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [x] Tested manually — describe how:
Triggered a Google OAuth token exchange failure locally. The handler now emits "ERROR api Google OAuth token exchange failed" with a full traceback, where previously the same failure recovered silently with only a 302 redirect and no log entry. Backend builds and boots cleanly with the change. Before/after log screenshots below.
- [ ] No tests required — explain why:

## Security Considerations
No security impact. This change only adds log statements and does not touch auth logic, secrets, permissions, or data exposure. The log messages are static strings and do not include tokens, credentials, or user data.

## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [ ] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
<img width="1058" height="97" alt="Before" src="https://github.com/user-attachments/assets/459d80b7-96d2-41ca-9ead-c44802a45fb4" />
Before: OAuth token exchange fails, only a 302 is logged with no error line.


<img width="1080" height="478" alt="image" src="https://github.com/user-attachments/assets/b4324701-9ff5-4a9b-85dd-77e02983f655" />
After: the same failure now logs "ERROR api Google OAuth token exchange failed" with a traceback pointing to auth.py.