### PR TITLE
Implement CIS 1.2.2 shared mailbox sign-in control

### DIFF
--- a/engine/collectors/exchange/mailbox/mailboxes.py
+++ b/engine/collectors/exchange/mailbox/mailboxes.py
@@ -21,17 +21,25 @@ class MailboxesDataCollector(BasePowerShellCollector):
     async def collect(self, client: PowerShellClient) -> dict[str, Any]:
         """Collect shared mailboxes and their associated user information."""
 
-        mailboxes = await client.run_cmdlet(
+        mailboxes_raw = await client.run_cmdlet(
             "ExchangeOnline",
             "Get-EXOMailbox",
             RecipientTypeDetails="SharedMailbox",
             ResultSize="Unlimited",
         )
 
-        if mailboxes is None:
+        mailboxes: list[dict[str, Any]]
+
+        if mailboxes_raw is None:
             mailboxes = []
-        elif isinstance(mailboxes, dict):
-            mailboxes = [mailboxes]
+        elif isinstance(mailboxes_raw, dict):
+            mailboxes = [mailboxes_raw]
+        elif isinstance(mailboxes_raw, list):
+            mailboxes = [
+                mailbox for mailbox in mailboxes_raw if isinstance(mailbox, dict)
+            ]
+        else:
+            mailboxes = []
 
         enriched_mailboxes = []
 
@@ -47,19 +55,19 @@ class MailboxesDataCollector(BasePowerShellCollector):
                 )
 
             enriched_mailboxes.append(
-            {
-                "display_name": mailbox.get("DisplayName"),
-                "user_principal_name": mailbox.get("UserPrincipalName"),
-                "external_directory_object_id": mailbox.get(
-                    "ExternalDirectoryObjectId"
-                ),
-                "account_disabled": (
-                    user_account.get("AccountDisabled")
-                    if isinstance(user_account, dict)
-                    else None
-                ),
-            }
-        )
+                {
+                    "display_name": mailbox.get("DisplayName"),
+                    "user_principal_name": mailbox.get("UserPrincipalName"),
+                    "external_directory_object_id": mailbox.get(
+                        "ExternalDirectoryObjectId"
+                    ),
+                    "account_disabled": (
+                        user_account.get("AccountDisabled")
+                        if isinstance(user_account, dict)
+                        else None
+                    ),
+                }
+            )
 
         return {
             "shared_mailboxes": enriched_mailboxes,

--- a/engine/collectors/exchange/mailbox/mailboxes.py
+++ b/engine/collectors/exchange/mailbox/mailboxes.py
@@ -5,7 +5,7 @@ CIS Microsoft 365 Foundations Benchmark Controls:
 
 Connection Method: Exchange Online PowerShell (via Docker container)
 Authentication: Client secret via MSAL -> access token passed to -AccessToken parameter
-Required Cmdlets: Get-EXOMailbox
+Required Cmdlets: Get-EXOMailbox, Get-User
 Required Permissions: Exchange.ManageAsApp + Exchange role assignment
 """
 
@@ -16,21 +16,11 @@ from collectors.powershell_client import PowerShellClient
 
 
 class MailboxesDataCollector(BasePowerShellCollector):
-    """Collects mailbox information for CIS compliance evaluation.
-
-    This collector retrieves shared mailboxes to verify
-    shared mailboxes have appropriate sign-in settings.
-    """
+    """Collects mailbox information for CIS compliance evaluation."""
 
     async def collect(self, client: PowerShellClient) -> dict[str, Any]:
-        """Collect mailbox data.
+        """Collect shared mailboxes and their associated user information."""
 
-        Returns:
-            Dict containing:
-            - shared_mailboxes: List of shared mailboxes
-            - total_shared_mailboxes: Count of shared mailboxes
-        """
-        # Get shared mailboxes only (RecipientTypeDetails -eq 'SharedMailbox')
         mailboxes = await client.run_cmdlet(
             "ExchangeOnline",
             "Get-EXOMailbox",
@@ -38,13 +28,40 @@ class MailboxesDataCollector(BasePowerShellCollector):
             ResultSize="Unlimited",
         )
 
-        # Handle None, single result, or list
         if mailboxes is None:
             mailboxes = []
         elif isinstance(mailboxes, dict):
             mailboxes = [mailboxes]
 
+        enriched_mailboxes = []
+
+        for mailbox in mailboxes:
+            user_principal_name = mailbox.get("UserPrincipalName")
+            user_account = None
+
+            if user_principal_name:
+                user_account = await client.run_cmdlet(
+                    "ExchangeOnline",
+                    "Get-User",
+                    Identity=user_principal_name,
+                )
+
+            enriched_mailboxes.append(
+            {
+                "display_name": mailbox.get("DisplayName"),
+                "user_principal_name": mailbox.get("UserPrincipalName"),
+                "external_directory_object_id": mailbox.get(
+                    "ExternalDirectoryObjectId"
+                ),
+                "account_disabled": (
+                    user_account.get("AccountDisabled")
+                    if isinstance(user_account, dict)
+                    else None
+                ),
+            }
+        )
+
         return {
-            "shared_mailboxes": mailboxes,
-            "total_shared_mailboxes": len(mailboxes),
+            "shared_mailboxes": enriched_mailboxes,
+            "total_shared_mailboxes": len(enriched_mailboxes),
         }

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.2.2_shared_mailbox_signin_blocked.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/1.2.2_shared_mailbox_signin_blocked.rego
@@ -1,0 +1,105 @@
+# METADATA
+# title: Ensure sign-in to shared mailboxes is blocked
+# description: |
+#   Shared mailboxes should not allow direct sign-in. Users should access them
+#   through their own accounts using delegated permissions.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-1.2.2
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: medium
+#   service: Exchange
+#   requires_permissions:
+#   - Exchange.ManageAsApp
+
+package cis.microsoft_365_foundations.v6_0_0.control_1_2_2
+
+import rego.v1
+
+default result := {
+  "compliant": false,
+  "message": "Evaluation failed: unable to verify shared mailbox sign-in status",
+  "details": {}
+}
+
+default compliant := false
+
+shared_mailboxes := object.get(input, "shared_mailboxes", [])
+
+non_compliant_mailboxes := [
+  mailbox |
+  some mailbox in shared_mailboxes
+  object.get(mailbox, "account_disabled", null) == false
+]
+
+unknown_status_mailboxes := [
+  mailbox |
+  some mailbox in shared_mailboxes
+  object.get(mailbox, "account_disabled", null) == null
+]
+
+compliant if {
+  count(unknown_status_mailboxes) == 0
+  count(non_compliant_mailboxes) == 0
+}
+
+result := output if {
+  count(unknown_status_mailboxes) == 0
+
+  output := {
+    "compliant": compliant,
+    "message": generate_message(
+      count(shared_mailboxes),
+      count(non_compliant_mailboxes)
+    ),
+    "affected_resources": non_compliant_mailboxes,
+    "details": {
+      "total_shared_mailboxes": count(shared_mailboxes),
+      "blocked_sign_in_count": count(shared_mailboxes) - count(non_compliant_mailboxes),
+      "direct_sign_in_enabled_count": count(non_compliant_mailboxes)
+    }
+  }
+}
+
+result := output if {
+  count(unknown_status_mailboxes) > 0
+
+  output := {
+    "compliant": false,
+    "message": sprintf(
+      "Unable to determine sign-in status for %d shared mailbox(es).",
+      [count(unknown_status_mailboxes)]
+    ),
+    "affected_resources": unknown_status_mailboxes,
+    "details": {
+      "total_shared_mailboxes": count(shared_mailboxes),
+      "unknown_status_count": count(unknown_status_mailboxes)
+    }
+  }
+}
+
+generate_message(total, non_compliant_count) := msg if {
+  total == 0
+  msg := "No shared mailboxes found."
+}
+
+generate_message(total, non_compliant_count) := msg if {
+  total > 0
+  non_compliant_count == 0
+  msg := sprintf(
+    "Sign-in is blocked for all %d shared mailbox(es).",
+    [total]
+  )
+}
+
+generate_message(total, non_compliant_count) := msg if {
+  non_compliant_count > 0
+  msg := sprintf(
+    "%d of %d shared mailbox(es) allow direct sign-in.",
+    [non_compliant_count, total]
+  )
+}

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -91,11 +91,11 @@
       "level": "L1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "exchange.mailbox.mailboxes",
-      "policy_file": null,
+      "policy_file": "1.2.2_shared_mailbox_signin_blocked.rego",
       "requires_permissions": ["Exchange.Manage"],
-      "notes": "Collector exists but control logic not defined"
+      "notes": "Collector and policy implemented"
     },
     {
       "control_id": "1.3.1",

--- a/engine/tests/test_cis_1_2_2_shared_mailbox_signin.rego
+++ b/engine/tests/test_cis_1_2_2_shared_mailbox_signin.rego
@@ -1,0 +1,178 @@
+package cis.microsoft_365_foundations.v6_0_0.test_control_1_2_2
+
+import rego.v1
+
+test_compliant_no_shared_mailboxes if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [],
+        "total_shared_mailboxes": 0,
+    }
+
+    result.compliant == true
+    result.message == "No shared mailboxes found."
+    result.details.total_shared_mailboxes == 0
+    result.details.direct_sign_in_enabled_count == 0
+}
+
+test_compliant_all_shared_mailboxes_blocked if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "11111111-1111-1111-1111-111111111111",
+                "account_disabled": true,
+            },
+            {
+                "display_name": "Finance Shared Mailbox",
+                "user_principal_name": "finance@contoso.com",
+                "external_directory_object_id": "22222222-2222-2222-2222-222222222222",
+                "account_disabled": true,
+            },
+        ],
+        "total_shared_mailboxes": 2,
+    }
+
+    result.compliant == true
+    result.message == "Sign-in is blocked for all 2 shared mailbox(es)."
+    result.details.total_shared_mailboxes == 2
+    result.details.blocked_sign_in_count == 2
+    result.details.direct_sign_in_enabled_count == 0
+    count(result.affected_resources) == 0
+}
+
+test_non_compliant_one_shared_mailbox_enabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "11111111-1111-1111-1111-111111111111",
+                "account_disabled": true,
+            },
+            {
+                "display_name": "Finance Shared Mailbox",
+                "user_principal_name": "finance@contoso.com",
+                "external_directory_object_id": "22222222-2222-2222-2222-222222222222",
+                "account_disabled": false,
+            },
+        ],
+        "total_shared_mailboxes": 2,
+    }
+
+    result.compliant == false
+    result.message == "1 of 2 shared mailbox(es) allow direct sign-in."
+    result.details.total_shared_mailboxes == 2
+    result.details.blocked_sign_in_count == 1
+    result.details.direct_sign_in_enabled_count == 1
+    count(result.affected_resources) == 1
+    result.affected_resources[0].user_principal_name == "finance@contoso.com"
+}
+
+test_non_compliant_all_shared_mailboxes_enabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "11111111-1111-1111-1111-111111111111",
+                "account_disabled": false,
+            },
+            {
+                "display_name": "Finance Shared Mailbox",
+                "user_principal_name": "finance@contoso.com",
+                "external_directory_object_id": "22222222-2222-2222-2222-222222222222",
+                "account_disabled": false,
+            },
+        ],
+        "total_shared_mailboxes": 2,
+    }
+
+    result.compliant == false
+    result.message == "2 of 2 shared mailbox(es) allow direct sign-in."
+    result.details.blocked_sign_in_count == 0
+    result.details.direct_sign_in_enabled_count == 2
+    count(result.affected_resources) == 2
+}
+
+test_non_compliant_unknown_status_null if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "33333333-3333-3333-3333-333333333333",
+                "account_disabled": null,
+            },
+        ],
+        "total_shared_mailboxes": 1,
+    }
+
+    result.compliant == false
+    result.message == "Unable to determine sign-in status for 1 shared mailbox(es)."
+    result.details.total_shared_mailboxes == 1
+    result.details.unknown_status_count == 1
+    count(result.affected_resources) == 1
+}
+
+test_non_compliant_missing_account_disabled if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "33333333-3333-3333-3333-333333333333",
+            },
+        ],
+        "total_shared_mailboxes": 1,
+    }
+
+    result.compliant == false
+    result.message == "Unable to determine sign-in status for 1 shared mailbox(es)."
+    result.details.unknown_status_count == 1
+}
+
+test_mixed_enabled_and_unknown_status_prefers_unknown_evaluation if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Finance Shared Mailbox",
+                "user_principal_name": "finance@contoso.com",
+                "external_directory_object_id": "22222222-2222-2222-2222-222222222222",
+                "account_disabled": false,
+            },
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "33333333-3333-3333-3333-333333333333",
+                "account_disabled": null,
+            },
+        ],
+        "total_shared_mailboxes": 2,
+    }
+
+    result.compliant == false
+    result.message == "Unable to determine sign-in status for 1 shared mailbox(es)."
+    result.details.unknown_status_count == 1
+}
+
+test_result_structure if {
+    result := data.cis.microsoft_365_foundations.v6_0_0.control_1_2_2.result with input as {
+        "shared_mailboxes": [
+            {
+                "display_name": "Support Shared Mailbox",
+                "user_principal_name": "support@contoso.com",
+                "external_directory_object_id": "11111111-1111-1111-1111-111111111111",
+                "account_disabled": true,
+            },
+        ],
+        "total_shared_mailboxes": 1,
+    }
+
+    _ = result.compliant
+    _ = result.message
+    _ = result.affected_resources
+    _ = result.details.total_shared_mailboxes
+    _ = result.details.blocked_sign_in_count
+    _ = result.details.direct_sign_in_enabled_count
+}


### PR DESCRIPTION
## Summary
Implements CIS 1.2.2 by updating the shared mailbox collector, adding the Rego policy and test, and updating the control metadata. 


## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [X] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
This control is required to automate CIS 1.2.2 and verify that shared mailbox sign-in is blocked as expected.


## Testing Done
<!-- What did you test and how? -->
- [X] Unit tests pass locally
- [ ] Tested manually — describe how:
- [ ] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [X] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [X] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [X] Code follows project conventions
- [X] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [X] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
