### PR TITLE
Implement CIS 3.1.1 audit log search control

### DIFF
--- a/engine/collectors/exchange/organization/admin_audit_log_config.py
+++ b/engine/collectors/exchange/organization/admin_audit_log_config.py
@@ -1,0 +1,44 @@
+"""Admin audit log config collector.
+
+CIS Microsoft 365 Foundations Benchmark Controls:
+    v6.0.0: 3.1.1
+
+Control Descriptions:
+    3.1.1 - Ensure Microsoft 365 audit log search is Enabled
+
+Connection Method: Exchange Online PowerShell (via Docker container)
+Authentication: Client secret via MSAL -> access token passed to -AccessToken parameter
+Required Cmdlets: Get-AdminAuditLogConfig
+Required Permissions: Exchange.ManageAsApp + Exchange role assignment
+"""
+
+from typing import Any
+
+from collectors.powershell_base import BasePowerShellCollector
+from collectors.powershell_client import PowerShellClient
+
+
+class AdminAuditLogConfigDataCollector(BasePowerShellCollector):
+    """Collects admin audit log config for CIS compliance evaluation.
+
+    This collector retrieves unified audit log ingestion settings used
+    by Microsoft 365 audit log search.
+    """
+
+    async def collect(self, client: PowerShellClient) -> dict[str, Any]:
+        """Collect admin audit log configuration data.
+
+        Returns:
+            Dict containing:
+            - admin_audit_log_config: Full admin audit log configuration
+            - unified_audit_log_ingestion_enabled: Unified audit log
+              ingestion status (CIS 3.1.1)
+        """
+        config = await client.run_cmdlet("ExchangeOnline", "Get-AdminAuditLogConfig")
+
+        return {
+            "admin_audit_log_config": config,
+            "unified_audit_log_ingestion_enabled": config.get(
+                "UnifiedAuditLogIngestionEnabled"
+            ),
+        }

--- a/engine/collectors/registry.py
+++ b/engine/collectors/registry.py
@@ -77,6 +77,9 @@ from collectors.exchange.dns.dns_security_records import (
 )
 
 # Exchange - Organization
+from collectors.exchange.organization.admin_audit_log_config import (
+    AdminAuditLogConfigDataCollector,
+)
 from collectors.exchange.organization.organization_config import (
     OrganizationConfigDataCollector,
 )
@@ -177,6 +180,7 @@ DATA_COLLECTORS: dict[str, type[BaseDataCollector]] = {
     # Exchange - DNS
     "exchange.dns.dns_security_records": DnsSecurityRecordsDataCollector,
     # Exchange - Organization
+    "exchange.organization.admin_audit_log_config": AdminAuditLogConfigDataCollector,
     "exchange.organization.organization_config": OrganizationConfigDataCollector,
     "exchange.organization.owa_mailbox_policy": OwaMailboxPolicyDataCollector,
     "exchange.organization.sharing_policy": SharingPolicyDataCollector,

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/3.1.1_microsoft_365_audit_log_search_enabled.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/3.1.1_microsoft_365_audit_log_search_enabled.rego
@@ -21,41 +21,41 @@ package cis.microsoft_365_foundations.v6_0_0.control_3_1_1
 
 default result := {
     "compliant": false,
-    "message": "Evaluation failed: unable to determine Microsoft 365 audit status",
+    "message": "Evaluation failed: unable to determine Microsoft 365 audit log search status",
     "affected_resources": [],
     "details": {}
 }
 
 result := output if {
-    audit_disabled := object.get(input, "audit_disabled", null)
+    enabled := object.get(input, "unified_audit_log_ingestion_enabled", null)
 
-    audit_disabled != null
+    enabled != null
 
-    # Compliant when auditing is not disabled
-    compliant := audit_disabled == false
+    # Compliant when unified audit log ingestion is enabled
+    compliant := enabled == true
 
     output := {
         "compliant": compliant,
-        "message": generate_message(audit_disabled),
-        "affected_resources": generate_affected_resources(audit_disabled),
+        "message": generate_message(enabled),
+        "affected_resources": generate_affected_resources(compliant),
         "details": {
-            "audit_disabled": audit_disabled
+            "unified_audit_log_ingestion_enabled": enabled
         }
     }
 }
 
-generate_message(audit_disabled) := msg if {
-    audit_disabled == false
-    msg := "Microsoft 365 audit log search is enabled"
+generate_message(enabled) := msg if {
+    enabled == true
+    msg := "Microsoft 365 audit log search is enabled (UnifiedAuditLogIngestionEnabled is True)"
 }
 
-generate_message(audit_disabled) := msg if {
-    audit_disabled == true
-    msg := "Microsoft 365 audit log search is disabled (AuditDisabled is True)"
+generate_message(enabled) := msg if {
+    enabled == false
+    msg := "Microsoft 365 audit log search is disabled (UnifiedAuditLogIngestionEnabled is False)"
 }
 
-generate_affected_resources(false) := []
+generate_affected_resources(true) := []
 
-generate_affected_resources(true) := [
-    "Microsoft 365 unified audit logging is disabled"
+generate_affected_resources(false) := [
+    "Microsoft 365 unified audit log ingestion is disabled"
 ]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/3.1.1_microsoft_365_audit_log_search_enabled.rego
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/3.1.1_microsoft_365_audit_log_search_enabled.rego
@@ -1,0 +1,61 @@
+# METADATA
+# title: Ensure Microsoft 365 audit log search is Enabled
+# description: |
+#   Microsoft 365 audit log search should be enabled to record user and
+#   administrator activities across the organization. This supports
+#   security monitoring, investigations, and compliance auditing.
+# related_resources:
+# - ref: https://www.cisecurity.org/benchmark/microsoft_365
+#   description: CIS Microsoft 365 Foundations Benchmark
+# custom:
+#   control_id: CIS-3.1.1
+#   framework: cis
+#   benchmark: microsoft-365-foundations
+#   version: v6.0.0
+#   severity: high
+#   service: Compliance
+#   requires_permissions:
+#   - Exchange.Manage
+
+package cis.microsoft_365_foundations.v6_0_0.control_3_1_1
+
+default result := {
+    "compliant": false,
+    "message": "Evaluation failed: unable to determine Microsoft 365 audit status",
+    "affected_resources": [],
+    "details": {}
+}
+
+result := output if {
+    audit_disabled := object.get(input, "audit_disabled", null)
+
+    audit_disabled != null
+
+    # Compliant when auditing is not disabled
+    compliant := audit_disabled == false
+
+    output := {
+        "compliant": compliant,
+        "message": generate_message(audit_disabled),
+        "affected_resources": generate_affected_resources(audit_disabled),
+        "details": {
+            "audit_disabled": audit_disabled
+        }
+    }
+}
+
+generate_message(audit_disabled) := msg if {
+    audit_disabled == false
+    msg := "Microsoft 365 audit log search is enabled"
+}
+
+generate_message(audit_disabled) := msg if {
+    audit_disabled == true
+    msg := "Microsoft 365 audit log search is disabled (AuditDisabled is True)"
+}
+
+generate_affected_resources(false) := []
+
+generate_affected_resources(true) := [
+    "Microsoft 365 unified audit logging is disabled"
+]

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -541,9 +541,9 @@
       "level": "L1",
       "is_manual": false,
       "benchmark_audit_type": "Automated",
-      "automation_status": "not_started",
+      "automation_status": "ready",
       "data_collector_id": "exchange.organization.organization_config",
-      "policy_file": null,
+      "policy_file":"3.1.1_microsoft_365_audit_log_search_enabled.rego",
       "requires_permissions": ["Exchange.Manage"],
       "notes": "Check AuditDisabled = False"
     },

--- a/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
+++ b/engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json
@@ -542,10 +542,10 @@
       "is_manual": false,
       "benchmark_audit_type": "Automated",
       "automation_status": "ready",
-      "data_collector_id": "exchange.organization.organization_config",
-      "policy_file":"3.1.1_microsoft_365_audit_log_search_enabled.rego",
+      "data_collector_id": "exchange.organization.admin_audit_log_config",
+      "policy_file": "3.1.1_microsoft_365_audit_log_search_enabled.rego",
       "requires_permissions": ["Exchange.Manage"],
-      "notes": "Check AuditDisabled = False"
+      "notes": "Check UnifiedAuditLogIngestionEnabled = True"
     },
     {
       "control_id": "3.2.1",


### PR DESCRIPTION
## Summary
Implements CIS 3.1.1 by adding the Rego policy and updating the control metadata to verify that Microsoft 365 audit log search is enabled.


## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [X] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
This control is required to automate CIS 3.1.1 and verify that audit log search is enabled.


## Testing Done
<!-- What did you test and how? -->
- [X] Unit tests pass locally
- [ ] Tested manually — describe how:
- [ ] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [X] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [X] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [X] Code follows project conventions
- [X] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [X] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
