### PR TITLE
sec: externalize hardcoded secrets in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,13 @@
 #
 # To test collectors with PowerShell service:
 #   cd engine && uv run python -m scripts.test_collector -c exchange.organization.organization_config --use-service http://localhost:8001
+#
+# NOTE: If you're upgrading an existing local environment after this change,
+# your postgres_data volume still has the OLD password baked in, and any
+# saved connections in your dev DB were encrypted with the OLD ENCRYPTION_KEY.
+# Reset your local state with:
+#   docker compose down -v
+# before starting with the new .env values. This is dev-only data — safe to discard.
 
 services:
   # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     container_name: autoaudit-db
     environment:
       POSTGRES_USER: autoaudit
-      POSTGRES_PASSWORD: autoaudit_dev_password  # pragma: allowlist secret
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD not set — see env.example}
       POSTGRES_DB: autoaudit
     ports:
       - "5432:5432"
@@ -101,10 +101,10 @@ services:
       - APP_ENV=dev
 
       # Required: Database connection (PostgreSQL with asyncpg driver)
-      - DATABASE_URL=postgresql+asyncpg://autoaudit:autoaudit_dev_password@db:5432/autoaudit
+      - DATABASE_URL=postgresql+asyncpg://autoaudit:${POSTGRES_PASSWORD}@db:5432/autoaudit
 
       # Required: JWT signing key (CHANGE IN PRODUCTION)
-      - SECRET_KEY=dev-secret-key-change-in-production
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY not set — see env.example}
 
       # Public URLs (used for OAuth redirects)
       - BACKEND_PUBLIC_URL=http://localhost:8000
@@ -123,7 +123,7 @@ services:
       # Required: Fernet encryption key for M365 credentials at rest
       # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
       # This will be passed in with a secret provider in production. This is for local use only.
-      - ENCRYPTION_KEY=Ps-HiS3ww5QzQPc_Mdu5-JyA_jCNbdFHMdiwWSlAfgM=
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY not set — see env.example}
 
       # Optional: Path to policies directory (default: /app/policies)
       - POLICIES_DIR=/app/policies
@@ -154,7 +154,7 @@ services:
     container_name: autoaudit-worker
     environment:
       # Required: Database connection (PostgreSQL - worker uses sync driver)
-      - DATABASE_URL=postgresql+asyncpg://autoaudit:autoaudit_dev_password@db:5432/autoaudit
+      - DATABASE_URL=postgresql+asyncpg://autoaudit:${POSTGRES_PASSWORD}@db:5432/autoaudit
 
       # Required: Redis URL for Celery broker
       - REDIS_URL=redis://redis:6379
@@ -163,7 +163,7 @@ services:
       - OPA_URL=http://opa:8181
 
       # Required: Must match ENCRYPTION_KEY in backend-api for credential decryption
-      - ENCRYPTION_KEY=Ps-HiS3ww5QzQPc_Mdu5-JyA_jCNbdFHMdiwWSlAfgM=
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY not set — see env.example}
 
       # Optional: PowerShell service URL for Exchange/Teams cmdlets
       # When set, worker uses HTTP service instead of spawning Docker containers

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -37,6 +37,8 @@ You can start from the template:
 cp env.example .env
 ```
 
+Before continuing, open `.env` and fill in `POSTGRES_PASSWORD`, `SECRET_KEY`, and `ENCRYPTION_KEY` — these are required and have no default value. Generation commands for each are documented as comments in `env.example`.
+
 ```bash
 docker compose --profile all up --build -d
 ```

--- a/env.example
+++ b/env.example
@@ -8,5 +8,15 @@
 GOOGLE_OAUTH_CLIENT_ID= 237734019606-8lft9r71d02ljcegsq4d6huglh8ke151.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET= 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
 
+# Postgres (used by db, backend-api, worker)
+POSTGRES_PASSWORD=
+
+# JWT signing key (backend-api)
+# Generate with: openssl rand -hex 32
+SECRET_KEY=
+
+# Fernet key for encrypting stored M365/AWS/Azure/GCP credentials (backend-api + worker, MUST match)
+# Generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ENCRYPTION_KEY=
 
 

--- a/env.example
+++ b/env.example
@@ -9,6 +9,8 @@ GOOGLE_OAUTH_CLIENT_ID= 237734019606-8lft9r71d02ljcegsq4d6huglh8ke151.apps.googl
 GOOGLE_OAUTH_CLIENT_SECRET= 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
 
 # Postgres (used by db, backend-api, worker)
+# Generate with: openssl rand -hex 16
+# Must be URL-safe (hex avoids characters that break the DATABASE_URL connection string)
 POSTGRES_PASSWORD=
 
 # JWT signing key (backend-api)


### PR DESCRIPTION
## Summary
Removes three hardcoded credentials from docker-compose.yml (POSTGRES_PASSWORD, SECRET_KEY, ENCRYPTION_KEY) and replaces them with `${VAR:?}` references sourced from a local, gitignored `.env` file. The previously-exposed Fernet ENCRYPTION_KEY has been rotated, the new value only exists in local `.env` files, never in version control. env.example is updated with the three new required variables and generation instructions for each.

## Type of Change
- [x] Security

## Affected Components
- [x] `/infrastructure` (docker-compose.yml is root-level dev infra config)

## Motivation
Covers Planner task 26T2-DEV-RR-002 (Workstream 4). Follows directly from the baseline audit (26T2-SEC-RR-001), which documented three real credentials sitting in plaintext in docker-compose.yml, including a live Fernet key actively used to encrypt stored M365/AWS/Azure/GCP credentials at rest. This closes that finding by moving all three to environment variables that are never committed.

## Testing Done
- [x] Tested manually — describe how: Generated three new values locally (Fernet key, SECRET_KEY, Postgres password), populated a local `.env`, and ran `docker compose --profile all up --build -d` with a fresh volume. Confirmed Postgres authentication succeeded with the new `.env`-sourced password (proving the `${VAR}` substitution works correctly) before hitting an unrelated, pre-existing Alembic "multiple head revisions" migration error. Verified this error is not caused by this change by reproducing it against unmodified `main` as well.

## Security Considerations
This is the core fix for the credential-exposure finding in the Week 4/5 baseline audit. The old ENCRYPTION_KEY value is treated as compromised (it was exposed in git history) and has been rotated, not just relocated; the new key only exists in local `.env` files. `.env` is already covered by `.gitignore`. `env.example` keeps blank placeholders only, with generation commands documented as comments.

## Breaking Changes
- [x] Yes — describe below:
Anyone running the stack locally now needs a `.env` file (`cp env.example .env`) populated with `POSTGRES_PASSWORD`, `SECRET_KEY`, and `ENCRYPTION_KEY` before `docker compose up` will work; previously, these had working defaults baked into docker-compose.yml. Generation commands for each are documented in env.example.

## Rollback Plan
- [x] Revert commit is sufficient

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [x] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch
- [x] PR is focused on one thing

## Screenshots
N/A — infra config change, no UI impact.