### PR TITLE
Add SharePoint PnP routing support

### DIFF
--- a/engine/worker/tasks.py
+++ b/engine/worker/tasks.py
@@ -32,7 +32,9 @@ def load_metadata(framework: str, benchmark: str, version: str) -> dict:
     Returns:
         The metadata dict containing controls list.
     """
-    metadata_path = Path(settings.POLICIES_DIR) / framework / benchmark / version / "metadata.json"
+    metadata_path = (
+        Path(settings.POLICIES_DIR) / framework / benchmark / version / "metadata.json"
+    )
     if not metadata_path.exists():
         raise FileNotFoundError(f"Metadata not found: {metadata_path}")
 
@@ -133,7 +135,9 @@ def run_scan(scan_id: int) -> dict:
             # explicitly disabled via ENABLE_POWERSHELL_CONTROLS=false.
             if (
                 settings.ENABLE_POWERSHELL_CONTROLS is False
-                and collector_id.startswith(("exchange.", "compliance.", "teams."))
+                and collector_id.startswith(
+                    ("exchange.", "compliance.", "teams.", "sharepoint.pnp.")
+                )
                 and not collector_id.startswith("exchange.dns.")
             ):
                 with get_db_session() as session:
@@ -357,9 +361,9 @@ async def _evaluate_control_async(
     #
     # Most Exchange and Compliance collectors require PowerShell, but a few Exchange
     # collectors use Graph (e.g. domain metadata).
-    if collector_id.startswith(("exchange.", "compliance.")) and not collector_id.startswith(
-        "exchange.dns."
-    ):
+    if collector_id.startswith(
+        ("exchange.", "compliance.", "sharepoint.pnp.")
+    ) and not collector_id.startswith("exchange.dns."):
         client = PowerShellClient(
             tenant_id=credentials["tenant_id"],
             client_id=credentials["client_id"],


### PR DESCRIPTION
## Summary
Adds Worker routing support for sharepoint.pnp.* collectors through the PowerShell service and includes them in PowerShell control handling.


## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [X] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->


## Testing Done
<!-- What did you test and how? -->
- [X] Unit tests pass locally
- [ ] Tested manually — describe how:
- [ ] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [X] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [X] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [X] Code follows project conventions
- [X] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [X] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
