### PR TITLE
hotfix/Fix terminal scan retry handling

### DIFF
--- a/engine/worker/tasks.py
+++ b/engine/worker/tasks.py
@@ -301,11 +301,10 @@ def evaluate_control(
         }
 
     except Exception as exc:
-        # Retry on failure
-        try:
-            raise self.retry(exc=exc)
-        except self.MaxRetriesExceededError:
-            # Max retries exceeded - mark as error
+        # self.request.retries is the number of retries already performed.
+        # Once the retry limit is reached, persist the terminal error
+        # instead of scheduling another retry.
+        if self.max_retries is not None and self.request.retries >= self.max_retries:
             with get_db_session() as session:
                 update_scan_result(
                     session,
@@ -318,11 +317,14 @@ def evaluate_control(
                 # Check if this was the last control and finalize scan if complete
                 finalize_scan_if_complete(session, scan_id)
                 session.commit()
+
             return {
                 "control_id": control_id,
                 "compliant": None,
                 "error": str(exc),
             }
+
+        raise self.retry(exc=exc)
 
 
 async def _evaluate_control_async(


### PR DESCRIPTION
## Summary
Fixes terminal scan retry handling so exhausted Celery retries are persisted as control errors and the scan can complete instead of remaining stuck.


## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [x] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [ ] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->


## Testing Done
<!-- What did you test and how? -->
- [x] Unit tests pass locally
- [ ] Tested manually — describe how:
- [ ] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [x] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
