### PR TITLE
Add SharePoint local runtime and control development guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ env/
 
 # Engine legacy generated outputs
 engine/legacy/engine/autoaudit_reports.json
+
+# Local SharePoint runtime override
+docker-compose.sharepoint.override.yml

--- a/docker-compose.sharepoint.override.yml.example
+++ b/docker-compose.sharepoint.override.yml.example
@@ -1,0 +1,13 @@
+# Copy to docker-compose.sharepoint.override.yml and change only the two host paths.
+
+services:
+  worker:
+    environment:
+      - SHAREPOINT_ADMIN_URL=https://t8sjf-admin.sharepoint.com
+      - SHAREPOINT_CERT_ALIAS=t8sjf
+  powershell-service:
+    environment:
+      - SHAREPOINT_CERT_ALIASES={"t8sjf":{"path":"/certs/aliases/t8sjf.pfx","password_file":"/certs/aliases/t8sjf.password"}}
+    volumes:
+      - /home/<USER>/autoaudit-sharepoint-cert/t8sjf.pfx:/certs/aliases/t8sjf.pfx:ro
+      - /home/<USER>/autoaudit-sharepoint-cert/t8sjf.password:/certs/aliases/t8sjf.password:ro

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -155,7 +155,7 @@ docker compose --profile all up --build -d
 
 The worker logs are output directly to the Docker logs. You can view them with `docker compose logs -f worker`.
 
-SharePoint scans: [SharePoint local runtime](./engine/sharepoint-local-runtime.md).
+SharePoint scans: [SharePoint local runtime](./engine/sharepoint-local-runtime.md). SharePoint controls: [SharePoint control development](./engine/sharepoint-control-development.md).
 
 ## Verifying Your Setup
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -155,6 +155,8 @@ docker compose --profile all up --build -d
 
 The worker logs are output directly to the Docker logs. You can view them with `docker compose logs -f worker`.
 
+SharePoint scans: [SharePoint local runtime](./engine/sharepoint-local-runtime.md).
+
 ## Verifying Your Setup
 
 Here's how to confirm everything is working:

--- a/docs/engine/sharepoint-control-development.md
+++ b/docs/engine/sharepoint-control-development.md
@@ -1,84 +1,48 @@
 # SharePoint Control Development
 
-How to add a CIS SharePoint control using the existing PnP integration. Use CIS 7.3.1 as the reference.
+Use this guide to add a CIS SharePoint control using the existing PnP integration.
 
-## Before You Start
+Local setup: [SharePoint local runtime](./sharepoint-local-runtime.md).
 
-Set up certificates and Compose using [SharePoint local runtime](./sharepoint-local-runtime.md).
+## 1. Identify the Evidence
 
-- Reuse the existing SharePoint PnP path (`sharepoint.pnp.*`). Do not add a second SharePoint authentication flow.
-- Do not use or register REST-era collectors such as `sharepoint.spo_tenant`.
-- Collector IDs for this integration are `sharepoint.pnp.*`.
+Identify the CIS requirement, the SharePoint setting/property, the PnP/PowerShell cmdlet that returns it, and the expected compliant value.
 
-## 1. Check Existing Evidence First
+For tenant-wide settings, check `Get-PnPTenant` first.
 
-Before creating a collector, check whether a shared collector already returns the CIS property.
+## 2. Reuse an Existing Collector
 
-For tenant-wide settings, start with `sharepoint.pnp.tenant`, which runs `Get-PnPTenant` and returns the full tenant object plus normalized fields.
+Inspect `engine/collectors/sharepoint/pnp/`. For tenant settings, prefer `sharepoint.pnp.tenant`.
 
-If the raw cmdlet already includes the property:
+- Reuse an existing collector when possible.
+- Add a normalized field only if the policy needs it.
+- Do not create one collector per control.
+- Do not use or register `sharepoint.spo_*`.
 
-- reuse `sharepoint.pnp.tenant`
-- add a normalized field only if the policy needs it
-- do **not** create one collector per CIS control
+## 3. Update Metadata
 
-## 2. Follow CIS 7.3.1
+In `engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json`, set `automation_status` to `ready`, `data_collector_id` to the correct `sharepoint.pnp.*` collector, and `policy_file` to the new Rego file.
 
-```
-CIS 7.3.1
-  → sharepoint.pnp.tenant
-  → Get-PnPTenant
-  → DisallowInfectedFileDownload
-  → disallow_infected_file_download
-  → metadata + Rego
-```
+## 4. Add the Rego Policy
 
-| Piece | Location |
-|---|---|
-| Collector | `engine/collectors/sharepoint/pnp/tenant.py` |
-| Registry | `engine/collectors/registry.py` (`sharepoint.pnp.tenant`) |
-| Metadata | `engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json` (control `7.3.1`) |
-| Policy | `engine/policies/cis/microsoft-365-foundations/v6.0.0/7.3.1_disallow_infected_file_download.rego` |
+Add the policy under `engine/policies/cis/microsoft-365-foundations/v6.0.0/`.
 
-Normalized field:
+OPA receives the collector dict as root input (`input.<field_name>`). Handle compliant, non-compliant, and null/missing. Missing evidence must not silently pass.
 
-```text
-disallow_infected_file_download  ←  tenant["DisallowInfectedFileDownload"]
-```
+## 5. Add Tests
 
-Compliant when that field is `true`. Worker passes collector output to OPA as root `input`.
+Add focused tests for compliant, non-compliant, and null/missing. Then run the Engine tests.
 
-## 3. Implement Your Control
+## 6. Validate Locally
 
-1. Confirm the CIS requirement and the exact evidence property.
-2. Check whether `sharepoint.pnp.tenant` / `Get-PnPTenant` already returns it.
-3. Reuse the collector; add a normalized field if needed.
-4. Wire the control in metadata (`ready`, `sharepoint.pnp.*`, policy file).
-5. Add the Rego policy.
-6. Add focused tests.
+Use the shared SharePoint runtime: tests → runtime → real scan.
 
-A different SharePoint cmdlet can justify another **shared** PnP collector (for example sync restrictions via `Get-PnPTenantSyncClientRestriction`). Do not create a second tenant collector.
+`PASS` or `FAIL` from real tenant evidence is successful E2E. `ERROR`, authentication failure, collection failure, or missing evidence is a runtime or implementation problem.
 
-## 4. Rego
+## Rules
 
-Rego sees the collector dict at the root (not nested under a wrapper). For 7.3.1 that is `input.disallow_infected_file_download`.
-
-Handle:
-
-- compliant (`true` → pass)
-- non-compliant (`false` → fail)
-- null / missing → fail closed (must not silently pass)
-
-## 5. Validate
-
-targeted tests → Engine pytest → local SharePoint runtime → real scan
-
-`PASS` or `FAIL` from real tenant evidence is successful E2E. `ERROR`, authentication failure, collection failure, or missing evidence is a runtime failure.
-
-## Important Rules
-
-- Never commit certificates, passwords, or `docker-compose.sharepoint.override.yml`.
-- Do not duplicate SharePoint auth, routing, or client code.
-- Do not register `sharepoint.spo_tenant`.
-- Reuse shared `sharepoint.pnp.*` collectors.
-- Before changing collector output shape, check other controls that consume it.
+- Reuse `sharepoint.pnp.*`.
+- Do not use `sharepoint.spo_*`.
+- Do not create another SharePoint authentication flow.
+- Do not commit certificates, passwords, or `docker-compose.sharepoint.override.yml`.
+- Check other controls before changing a shared collector.

--- a/docs/engine/sharepoint-control-development.md
+++ b/docs/engine/sharepoint-control-development.md
@@ -1,0 +1,84 @@
+# SharePoint Control Development
+
+How to add a CIS SharePoint control using the existing PnP integration. Use CIS 7.3.1 as the reference.
+
+## Before You Start
+
+Set up certificates and Compose using [SharePoint local runtime](./sharepoint-local-runtime.md).
+
+- Reuse the existing SharePoint PnP path (`sharepoint.pnp.*`). Do not add a second SharePoint authentication flow.
+- Do not use or register REST-era collectors such as `sharepoint.spo_tenant`.
+- Collector IDs for this integration are `sharepoint.pnp.*`.
+
+## 1. Check Existing Evidence First
+
+Before creating a collector, check whether a shared collector already returns the CIS property.
+
+For tenant-wide settings, start with `sharepoint.pnp.tenant`, which runs `Get-PnPTenant` and returns the full tenant object plus normalized fields.
+
+If the raw cmdlet already includes the property:
+
+- reuse `sharepoint.pnp.tenant`
+- add a normalized field only if the policy needs it
+- do **not** create one collector per CIS control
+
+## 2. Follow CIS 7.3.1
+
+```
+CIS 7.3.1
+  → sharepoint.pnp.tenant
+  → Get-PnPTenant
+  → DisallowInfectedFileDownload
+  → disallow_infected_file_download
+  → metadata + Rego
+```
+
+| Piece | Location |
+|---|---|
+| Collector | `engine/collectors/sharepoint/pnp/tenant.py` |
+| Registry | `engine/collectors/registry.py` (`sharepoint.pnp.tenant`) |
+| Metadata | `engine/policies/cis/microsoft-365-foundations/v6.0.0/metadata.json` (control `7.3.1`) |
+| Policy | `engine/policies/cis/microsoft-365-foundations/v6.0.0/7.3.1_disallow_infected_file_download.rego` |
+
+Normalized field:
+
+```text
+disallow_infected_file_download  ←  tenant["DisallowInfectedFileDownload"]
+```
+
+Compliant when that field is `true`. Worker passes collector output to OPA as root `input`.
+
+## 3. Implement Your Control
+
+1. Confirm the CIS requirement and the exact evidence property.
+2. Check whether `sharepoint.pnp.tenant` / `Get-PnPTenant` already returns it.
+3. Reuse the collector; add a normalized field if needed.
+4. Wire the control in metadata (`ready`, `sharepoint.pnp.*`, policy file).
+5. Add the Rego policy.
+6. Add focused tests.
+
+A different SharePoint cmdlet can justify another **shared** PnP collector (for example sync restrictions via `Get-PnPTenantSyncClientRestriction`). Do not create a second tenant collector.
+
+## 4. Rego
+
+Rego sees the collector dict at the root (not nested under a wrapper). For 7.3.1 that is `input.disallow_infected_file_download`.
+
+Handle:
+
+- compliant (`true` → pass)
+- non-compliant (`false` → fail)
+- null / missing → fail closed (must not silently pass)
+
+## 5. Validate
+
+targeted tests → Engine pytest → local SharePoint runtime → real scan
+
+`PASS` or `FAIL` from real tenant evidence is successful E2E. `ERROR`, authentication failure, collection failure, or missing evidence is a runtime failure.
+
+## Important Rules
+
+- Never commit certificates, passwords, or `docker-compose.sharepoint.override.yml`.
+- Do not duplicate SharePoint auth, routing, or client code.
+- Do not register `sharepoint.spo_tenant`.
+- Reuse shared `sharepoint.pnp.*` collectors.
+- Before changing collector output shape, check other controls that consume it.

--- a/docs/engine/sharepoint-local-runtime.md
+++ b/docs/engine/sharepoint-local-runtime.md
@@ -1,0 +1,82 @@
+# SharePoint Online local scan runtime
+
+Run all commands from the AutoAudit project root (`.../AutoAudit/`), not `.../AutoAudit/engine/`, unless a step says otherwise.
+
+Keep certificate and password files **outside the repo**. Never commit them, and never commit `docker-compose.sharepoint.override.yml`.
+
+## 1. Pull latest `main`
+
+```bash
+git switch main
+git pull
+```
+
+## 2. Save the provided files
+
+Contact the Team Lead for `t8sjf.pfx` and `t8sjf.password`. Do not generate your own certificate for this shared test runtime.
+
+Place those files in `~/autoaudit-sharepoint-cert/`:
+
+```bash
+mkdir -p ~/autoaudit-sharepoint-cert
+```
+
+The folder must look like this:
+
+```
+~/autoaudit-sharepoint-cert/
+├── t8sjf.pfx
+└── t8sjf.password
+```
+
+Confirm they are **files** (not directories) before starting Docker. If the paths are missing, Docker may create directories with those names and SharePoint collection will fail:
+
+```bash
+test -f ~/autoaudit-sharepoint-cert/t8sjf.pfx && echo "PFX OK"
+test -f ~/autoaudit-sharepoint-cert/t8sjf.password && echo "Password OK"
+```
+
+Both commands should print `OK` before you run Docker Compose.
+
+## 3. Copy the override
+
+```bash
+cp docker-compose.sharepoint.override.yml.example docker-compose.sharepoint.override.yml
+```
+
+Edit only the two host paths. Docker needs **absolute** host paths (not `~`). Those files are mounted **read-only** into the PowerShell container:
+
+```yaml
+- /home/<USER>/autoaudit-sharepoint-cert/t8sjf.pfx:/certs/aliases/t8sjf.pfx:ro
+- /home/<USER>/autoaudit-sharepoint-cert/t8sjf.password:/certs/aliases/t8sjf.password:ro
+```
+
+## 4. Start worker and PowerShell
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.sharepoint.override.yml \
+  --profile worker --profile powershell \
+  up -d --build worker powershell-service
+```
+
+## 5. Confirm they are running
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.sharepoint.override.yml \
+  --profile worker --profile powershell \
+  ps
+```
+
+`worker` and `powershell-service` should be up.
+
+## 6. Run the scan
+
+You do not need to run `Connect-PnPOnline` yourself. AutoAudit connects to SharePoint PnP during the scan.
+
+In the app, use the M365 connection for the **t8sjf** tenant/application that matches the provided certificate. If you pick a different tenant, Graph and Exchange can scan that tenant while SharePoint PnP still uses t8sjf.
+
+Open http://localhost:3000 and start a scan.


### PR DESCRIPTION
## Summary
Adds documentation for working with the SharePoint PnP integration locally and developing new SharePoint CIS controls.

This PR includes:
- SharePoint local runtime setup guide
- SharePoint control development guide
- Docker Compose override example for the shared SharePoint runtime
- Git ignore rule for the local SharePoint override
- Links to the new guides from GETTING_STARTED.md

The control development guide provides a short workflow for reusing the existing sharepoint.pnp.* collectors, wiring metadata and Rego policies, adding tests, and validating controls locally.

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI/CD / infrastructure
- [ ] Security

## Affected Components
<!-- Check all modules touched by this PR -->
- [ ] `/backend-api`
- [ ] `/frontend`
- [ ] `/engine` (collectors / policies)
- [ ] `/security`
- [ ] `/infrastructure`
- [ ] `/.github/workflows`
- [x] `/docs`

## Motivation
<!-- Why was this change needed? Link to a Planner task if there is one. -->


## Testing Done
<!-- What did you test and how? -->
- [ ] Unit tests pass locally
- [ ] Tested manually — describe how:
- [x] No tests required — explain why:

## Security Considerations
<!-- Does this change affect auth, secrets, API permissions, or data exposure? If there's no security impact, just say so. -->


## Breaking Changes
<!-- Does this break any existing API contracts, env vars, DB schemas, or workflows? -->
- [x] No breaking changes
- [ ] Yes — describe below:


## Rollback Plan
<!-- How would this be reverted if something goes wrong after merging?
     If there are DB migrations, include the downgrade command. -->
- [x] Revert commit is sufficient
- [ ] Requires additional steps — describe below:

## Checklist
- [ ] Code follows project conventions
- [x] No secrets, credentials, or tokens committed
- [ ] Relevant documentation updated (if applicable)
- [ ] CI/CD workflows pass on this branch 
- [x] PR is focused on one thing

## Screenshots
<!-- Frontend changes or anything visual worth showing. Remove if not needed. -->
